### PR TITLE
Introduced EventLoop::readable and EventLoop::writable

### DIFF
--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -155,6 +155,42 @@ class EventLoop implements \M6Web\Tornado\EventLoop
         return $deferred;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function readable($stream): Promise
+    {
+        $deferred = new \Amp\Deferred();
+
+        \Amp\Loop::onReadable(
+            $stream,
+            function ($watcherId, $stream) use ($deferred) {
+                \Amp\Loop::cancel($watcherId);
+                $deferred->resolve($stream);
+            }
+        );
+
+        return self::fromAmpPromise($deferred->promise());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writable($stream): Promise
+    {
+        $deferred = new \Amp\Deferred();
+
+        \Amp\Loop::onWritable(
+            $stream,
+            function ($watcherId, $stream) use ($deferred) {
+                \Amp\Loop::cancel($watcherId);
+                $deferred->resolve($stream);
+            }
+        );
+
+        return self::fromAmpPromise($deferred->promise());
+    }
+
     private static function fromAmpPromise(\Amp\Promise $ampPromise): Promise
     {
         $promise = new class() implements Promise {

--- a/src/Adapter/ReactPhp/EventLoop.php
+++ b/src/Adapter/ReactPhp/EventLoop.php
@@ -176,6 +176,40 @@ class EventLoop implements \M6Web\Tornado\EventLoop
         return $deferred;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function readable($stream): Promise
+    {
+        $deferred = $this->deferred();
+        $this->reactEventLoop->addReadStream(
+            $stream,
+            function ($stream) use ($deferred) {
+                $this->reactEventLoop->removeReadStream($stream);
+                $deferred->resolve($stream);
+            }
+        );
+
+        return $deferred->getPromise();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writable($stream): Promise
+    {
+        $deferred = $this->deferred();
+        $this->reactEventLoop->addWriteStream(
+            $stream,
+            function ($stream) use ($deferred) {
+                $this->reactEventLoop->removeWriteStream($stream);
+                $deferred->resolve($stream);
+            }
+        );
+
+        return $deferred->getPromise();
+    }
+
     private static function fromReactPromise(\React\Promise\PromiseInterface $reactPromise): Promise
     {
         $promise = new class() implements Promise {

--- a/src/Adapter/Tornado/SynchronousEventLoop.php
+++ b/src/Adapter/Tornado/SynchronousEventLoop.php
@@ -143,4 +143,20 @@ class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
 
         return $deferred;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function readable($stream): Promise
+    {
+        return $this->promiseFulfilled($stream);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writable($stream): Promise
+    {
+        return $this->promiseFulfilled($stream);
+    }
 }

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -47,4 +47,22 @@ interface EventLoop
      * Creates a deferred, allowing to create and resolve your own promises.
      */
     public function deferred(): Deferred;
+
+    /**
+     * Returns a promise that will be resolved with the input stream when it becomes readable.
+     *
+     * @param $stream
+     *
+     * @return Promise
+     */
+    public function readable($stream): Promise;
+
+    /**
+     * Returns a promise that will be resolved with the input stream when it becomes writable.
+     *
+     * @param $stream
+     *
+     * @return Promise
+     */
+    public function writable($stream): Promise;
 }

--- a/tests/Adapter/Amp/EventLoopTest.php
+++ b/tests/Adapter/Amp/EventLoopTest.php
@@ -12,9 +12,9 @@ class EventLoopTest extends \M6WebTest\Tornado\EventLoopTest
         return new Amp\EventLoop();
     }
 
-    public function testReadableStream($expectedSequence = '')
+    public function testStreamShouldReadFromWritable($expectedSequence = '')
     {
         // Because AMP doesn't trigger write callback immediately
-        parent::testReadableStream('W0R0W12345R12R34R5W6R6R');
+        parent::testStreamShouldReadFromWritable('W0R0W12345R12R34R5W6R6R');
     }
 }

--- a/tests/Adapter/Amp/EventLoopTest.php
+++ b/tests/Adapter/Amp/EventLoopTest.php
@@ -11,4 +11,10 @@ class EventLoopTest extends \M6WebTest\Tornado\EventLoopTest
     {
         return new Amp\EventLoop();
     }
+
+    public function testReadableStream($expectedSequence = '')
+    {
+        // Because AMP doesn't trigger write callback immediately
+        parent::testReadableStream('W0R0W12345R12R34R5W6R6R');
+    }
 }

--- a/tests/Adapter/Tornado/SynchronousEventLoopTest.php
+++ b/tests/Adapter/Tornado/SynchronousEventLoopTest.php
@@ -29,4 +29,10 @@ class SynchronousEventLoopTest extends \M6WebTest\Tornado\EventLoopTest
         // In the synchronous case, there is no race, first promise always win
         parent::testPromiseRaceShouldRejectIfFirstSettledPromiseRejects(1);
     }
+
+    public function testReadableStream($expectedSequence = '')
+    {
+        // Never wait…
+        parent::testReadableStream('W0W12345W6R01R23R45R6R');
+    }
 }

--- a/tests/Adapter/Tornado/SynchronousEventLoopTest.php
+++ b/tests/Adapter/Tornado/SynchronousEventLoopTest.php
@@ -30,9 +30,9 @@ class SynchronousEventLoopTest extends \M6WebTest\Tornado\EventLoopTest
         parent::testPromiseRaceShouldRejectIfFirstSettledPromiseRejects(1);
     }
 
-    public function testReadableStream($expectedSequence = '')
+    public function testStreamShouldReadFromWritable($expectedSequence = '')
     {
         // Never wait…
-        parent::testReadableStream('W0W12345W6R01R23R45R6R');
+        parent::testStreamShouldReadFromWritable('W0W12345W6R01R23R45R6R');
     }
 }

--- a/tests/EventLoopTest.php
+++ b/tests/EventLoopTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 abstract class EventLoopTest extends TestCase
 {
     use
+        EventLoopTest\StreamsTest,
         EventLoopTest\PromiseAllTest,
         EventLoopTest\PromiseRaceTest;
 
@@ -224,60 +225,5 @@ abstract class EventLoopTest extends TestCase
 
         $this->expectException(get_class($expectedException));
         $eventLoop->wait($promise);
-    }
-
-    /**
-     * Returns a pair of two connected streams.
-     *
-     * @return resource[]
-     */
-    private function createStreamPair()
-    {
-        $domain = (DIRECTORY_SEPARATOR === '\\') ? STREAM_PF_INET : STREAM_PF_UNIX;
-        $sockets = stream_socket_pair($domain, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
-
-        foreach ($sockets as $socket) {
-            if (function_exists('stream_set_read_buffer')) {
-                stream_set_read_buffer($socket, 0);
-            }
-        }
-
-        return $sockets;
-    }
-
-    public function testReadableStream($expectedSequence = 'W0R0W12345R12R34W6R56R')
-    {
-        $tokens = ['0', '12345', '6'];
-        [$streamIn, $streamOut] = $this->createStreamPair();
-        stream_set_blocking($streamOut, false);
-        $sequence = '';
-
-        $writeToStream = function (EventLoop $eventLoop, $stream, array $tokens) use (&$sequence): \Generator {
-            // At the beginning, nothing can be read from the stream
-            yield $eventLoop->idle();
-            foreach ($tokens as $token) {
-                fwrite(yield $eventLoop->writable($stream), $token);
-                $sequence .= "W$token";
-                // Write twice slower
-                yield $eventLoop->idle();
-                yield $eventLoop->idle();
-            }
-            fclose($stream);
-        };
-
-        $readFromStream = function (EventLoop $eventLoop, $stream) use (&$sequence): \Generator {
-            do {
-                $token = fread(yield $eventLoop->readable($stream), 2);
-                $sequence .= "R$token";
-            } while (strlen($token));
-
-            return $sequence;
-        };
-
-        $eventLoop = $this->createEventLoop();
-        $eventLoop->async($writeToStream($eventLoop, $streamIn, $tokens));
-        $readPromise = $eventLoop->async($readFromStream($eventLoop, $streamOut));
-
-        $this->assertSame($expectedSequence, $eventLoop->wait($readPromise));
     }
 }

--- a/tests/EventLoopTest.php
+++ b/tests/EventLoopTest.php
@@ -225,4 +225,59 @@ abstract class EventLoopTest extends TestCase
         $this->expectException(get_class($expectedException));
         $eventLoop->wait($promise);
     }
+
+    /**
+     * Returns a pair of two connected streams.
+     *
+     * @return resource[]
+     */
+    private function createStreamPair()
+    {
+        $domain = (DIRECTORY_SEPARATOR === '\\') ? STREAM_PF_INET : STREAM_PF_UNIX;
+        $sockets = stream_socket_pair($domain, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+
+        foreach ($sockets as $socket) {
+            if (function_exists('stream_set_read_buffer')) {
+                stream_set_read_buffer($socket, 0);
+            }
+        }
+
+        return $sockets;
+    }
+
+    public function testReadableStream($expectedSequence = 'W0R0W12345R12R34W6R56R')
+    {
+        $tokens = ['0', '12345', '6'];
+        [$streamIn, $streamOut] = $this->createStreamPair();
+        stream_set_blocking($streamOut, false);
+        $sequence = '';
+
+        $writeToStream = function (EventLoop $eventLoop, $stream, array $tokens) use (&$sequence): \Generator {
+            // At the beginning, nothing can be read from the stream
+            yield $eventLoop->idle();
+            foreach ($tokens as $token) {
+                fwrite(yield $eventLoop->writable($stream), $token);
+                $sequence .= "W$token";
+                // Write twice slower
+                yield $eventLoop->idle();
+                yield $eventLoop->idle();
+            }
+            fclose($stream);
+        };
+
+        $readFromStream = function (EventLoop $eventLoop, $stream) use (&$sequence): \Generator {
+            do {
+                $token = fread(yield $eventLoop->readable($stream), 2);
+                $sequence .= "R$token";
+            } while (strlen($token));
+
+            return $sequence;
+        };
+
+        $eventLoop = $this->createEventLoop();
+        $eventLoop->async($writeToStream($eventLoop, $streamIn, $tokens));
+        $readPromise = $eventLoop->async($readFromStream($eventLoop, $streamOut));
+
+        $this->assertSame($expectedSequence, $eventLoop->wait($readPromise));
+    }
 }

--- a/tests/EventLoopTest/StreamsTest.php
+++ b/tests/EventLoopTest/StreamsTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace M6WebTest\Tornado\EventLoopTest;
+
+use M6Web\Tornado\EventLoop;
+
+trait StreamsTest
+{
+    abstract protected function createEventLoop(): EventLoop;
+
+    /**
+     * Returns a pair of two connected streams.
+     *
+     * @return resource[]
+     */
+    private function createStreamPair()
+    {
+        $domain = (DIRECTORY_SEPARATOR === '\\') ? STREAM_PF_INET : STREAM_PF_UNIX;
+        $sockets = stream_socket_pair($domain, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
+
+        foreach ($sockets as $socket) {
+            if (function_exists('stream_set_read_buffer')) {
+                stream_set_read_buffer($socket, 0);
+            }
+        }
+
+        return $sockets;
+    }
+
+    public function testStreamShouldReadFromWritable($expectedSequence = 'W0R0W12345R12R34W6R56R')
+    {
+        $tokens = ['0', '12345', '6'];
+        [$streamIn, $streamOut] = $this->createStreamPair();
+        stream_set_blocking($streamOut, false);
+        $sequence = '';
+
+        $writeToStream = function (EventLoop $eventLoop, $stream, array $tokens) use (&$sequence): \Generator {
+            // At the beginning, nothing can be read from the stream
+            yield $eventLoop->idle();
+            foreach ($tokens as $token) {
+                fwrite(yield $eventLoop->writable($stream), $token);
+                $sequence .= "W$token";
+                // Write twice slower
+                yield $eventLoop->idle();
+                yield $eventLoop->idle();
+            }
+            fclose($stream);
+        };
+
+        $readFromStream = function (EventLoop $eventLoop, $stream) use (&$sequence): \Generator {
+            do {
+                $token = fread(yield $eventLoop->readable($stream), 2);
+                $sequence .= "R$token";
+            } while (strlen($token));
+
+            return $sequence;
+        };
+
+        $eventLoop = $this->createEventLoop();
+        $eventLoop->async($writeToStream($eventLoop, $streamIn, $tokens));
+        $readPromise = $eventLoop->async($readFromStream($eventLoop, $streamOut));
+
+        $this->assertSame($expectedSequence, $eventLoop->wait($readPromise));
+    }
+
+    public function testStreamShouldBeWritableIfOpened()
+    {
+        $eventLoop = $this->createEventLoop();
+        [$streamIn, $streamOut] = $this->createStreamPair();
+
+        // If output stream is closed, input stream is always writable
+        fclose($streamOut);
+        $stream = $eventLoop->wait($eventLoop->writable($streamIn));
+        $this->assertSame($streamIn, $stream);
+    }
+
+    public function testStreamShouldNotBeWritableIfClosed()
+    {
+        $eventLoop = $this->createEventLoop();
+        [$streamIn, $streamOut] = $this->createStreamPair();
+
+        $waitSomeTicks = function () use ($eventLoop) {
+            yield $eventLoop->idle();
+            yield $eventLoop->idle();
+            yield $eventLoop->idle();
+
+            return 'Aborted';
+        };
+
+        // If stream is closed, the promise will never be resolved
+        fclose($streamIn);
+        $result = $eventLoop->wait(
+            $eventLoop->promiseRace(
+                $eventLoop->async($waitSomeTicks()),
+                $eventLoop->writable($streamIn)
+            )
+        );
+
+        $this->assertSame('Aborted', $result);
+    }
+
+    public function testStreamShouldNotBeReadableIfClosed()
+    {
+        $eventLoop = $this->createEventLoop();
+        [$streamIn, $streamOut] = $this->createStreamPair();
+
+        $waitSomeTicks = function () use ($eventLoop) {
+            yield $eventLoop->idle();
+            yield $eventLoop->idle();
+            yield $eventLoop->idle();
+
+            return 'Aborted';
+        };
+
+        // If stream is closed, the promise will never be resolved
+        fclose($streamOut);
+        $result = $eventLoop->wait(
+            $eventLoop->promiseRace(
+                $eventLoop->async($waitSomeTicks()),
+                $eventLoop->readable($streamOut)
+            )
+        );
+
+        $this->assertSame('Aborted', $result);
+    }
+}


### PR DESCRIPTION
Handle promise for streams to comply with other frameworks capabilities.
See [ReactPhp doc](https://reactphp.org/event-loop/#addreadstream) and [Amp doc](https://amphp.org/amp/event-loop/api#onreadable).

Tornado prefers promises over callback, here an example of how to use this new feature:
```php
function readStream($stream): \Generator
{
    $content = '';
    $part = fread(yield $eventLoop->readable($stream), 1024);
    while($part !== '') {
        $content .= $part;
        $content = fread(yield $eventLoop->readable($stream), 1024);
    }
    return $content;
}
```
It's a low level API by design, it doesn't handle the way to read/write from/to a stream.

## TODO
* [x] More tests on edge cases
* [ ] ~Improve internal naming for Tornado adapter~ Looking forward to an internal refactoring to isolate various behaviors.

## Notice
Internal code of Tornado adapter becomes really messy, it will require an internal refactoring in a further PR…