### PR TITLE
Feature/promise race

### DIFF
--- a/src/Adapter/ReactPhp/EventLoop.php
+++ b/src/Adapter/ReactPhp/EventLoop.php
@@ -102,12 +102,19 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseAll(Promise ...$promises): Promise
     {
-        $reactPromises = [];
-        foreach ($promises as $promise) {
-            $reactPromises[] = self::toReactPromise($promise);
-        }
+        $reactPromises = array_map([self::class, 'toReactPromise'], $promises);
 
         return self::fromReactPromise(\React\Promise\all($reactPromises));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function promiseRace(Promise ...$promises): Promise
+    {
+        $reactPromises = array_map([self::class, 'toReactPromise'], $promises);
+
+        return self::fromReactPromise(\React\Promise\race($reactPromises));
     }
 
     /**

--- a/src/Adapter/Tornado/EventLoop.php
+++ b/src/Adapter/Tornado/EventLoop.php
@@ -51,12 +51,15 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseAll(Promise ...$promises): Promise
     {
-        $globalPromise = $this->promisePending();
         $nbPromises = count($promises);
+        if ($nbPromises === 0) {
+            return $this->promiseFulfilled([]);
+        }
+
+        $globalPromise = $this->promisePending();
         $allResults = [];
 
-        // To be sure that the last resolved promise resolves the global promise immediately,
-        //
+        // To ensure that the last resolved promise resolves the global promise immediately
         $waitOnePromise = function (int $index, Promise $promise) use ($globalPromise, $nbPromises, &$allResults): \Generator {
             try {
                 $allResults[$index] = yield $promise;

--- a/src/Adapter/Tornado/SynchronousEventLoop.php
+++ b/src/Adapter/Tornado/SynchronousEventLoop.php
@@ -70,6 +70,14 @@ class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
     /**
      * {@inheritdoc}
      */
+    public function promiseRace(Promise ...$promises): Promise
+    {
+        return reset($promises) ?: $this->promiseFulfilled(null);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function promiseFulfilled($value): Promise
     {
         $promise = new class() implements Promise {

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -24,6 +24,11 @@ interface EventLoop
     public function promiseAll(Promise ...$promises): Promise;
 
     /**
+     * Creates a promise that will behave like the first settled input promise, while others will be ignored.
+     **/
+    public function promiseRace(Promise ...$promises): Promise;
+
+    /**
      * Creates a promise already resolved with $value.
      */
     public function promiseFulfilled($value): Promise;

--- a/tests/Adapter/Tornado/SynchronousEventLoopTest.php
+++ b/tests/Adapter/Tornado/SynchronousEventLoopTest.php
@@ -17,4 +17,16 @@ class SynchronousEventLoopTest extends \M6WebTest\Tornado\EventLoopTest
         //By definition, this is not an asynchronous EventLoop
         parent::testIdle('AAABBC');
     }
+
+    public function testPromiseRaceShouldResolvePromisesArray(int $expectedValue = 2)
+    {
+        // In the synchronous case, there is no race, first promise always win
+        parent::testPromiseRaceShouldResolvePromisesArray(1);
+    }
+
+    public function testPromiseRaceShouldRejectIfFirstSettledPromiseRejects(int $expectedValue = 2)
+    {
+        // In the synchronous case, there is no race, first promise always win
+        parent::testPromiseRaceShouldRejectIfFirstSettledPromiseRejects(1);
+    }
 }

--- a/tests/EventLoopTest.php
+++ b/tests/EventLoopTest.php
@@ -9,7 +9,9 @@ use PHPUnit\Framework\TestCase;
 
 abstract class EventLoopTest extends TestCase
 {
-    use EventLoopTest\PromiseAllTest;
+    use
+        EventLoopTest\PromiseAllTest,
+        EventLoopTest\PromiseRaceTest;
 
     abstract protected function createEventLoop(): EventLoop;
 

--- a/tests/EventLoopTest.php
+++ b/tests/EventLoopTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\TestCase;
 
 abstract class EventLoopTest extends TestCase
 {
+    use EventLoopTest\PromiseAllTest;
+
     abstract protected function createEventLoop(): EventLoop;
 
     public function testFulfilledPromise()
@@ -31,37 +33,6 @@ abstract class EventLoopTest extends TestCase
 
         $eventLoop = $this->createEventLoop();
         $promise = $eventLoop->promiseRejected($expectedException);
-
-        $this->expectException(get_class($expectedException));
-        $eventLoop->wait($promise);
-    }
-
-    public function testAllPromisesFulfilled()
-    {
-        $expectedValues = [1, 'ok', new \stdClass(), ['array']];
-
-        $eventLoop = $this->createEventLoop();
-        $promises = array_map([$eventLoop, 'promiseFulfilled'], $expectedValues);
-        $promise = $eventLoop->promiseAll(...$promises);
-
-        $this->assertEquals(
-            $expectedValues,
-            $eventLoop->wait($promise)
-        );
-    }
-
-    public function testAllPromisesRejected()
-    {
-        $expectedException = new class() extends \Exception {
-        };
-
-        $eventLoop = $this->createEventLoop();
-        $promise = $eventLoop->promiseAll(
-            $eventLoop->promiseFulfilled(1),
-            $eventLoop->promiseRejected($expectedException),
-            $eventLoop->promiseFulfilled(2),
-            $eventLoop->promiseRejected(new \Exception())
-        );
 
         $this->expectException(get_class($expectedException));
         $eventLoop->wait($promise);

--- a/tests/EventLoopTest/PromiseAllTest.php
+++ b/tests/EventLoopTest/PromiseAllTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace M6WebTest\Tornado\EventLoopTest;
+
+use M6Web\Tornado\EventLoop;
+
+trait PromiseAllTest
+{
+    abstract protected function createEventLoop(): EventLoop;
+
+    public function testAllPromisesFulfilled()
+    {
+        $expectedValues = [1, 'ok', new \stdClass(), ['array']];
+
+        $eventLoop = $this->createEventLoop();
+        $promises = array_map([$eventLoop, 'promiseFulfilled'], $expectedValues);
+        $promise = $eventLoop->promiseAll(...$promises);
+
+        $this->assertEquals(
+            $expectedValues,
+            $eventLoop->wait($promise)
+        );
+    }
+
+    public function testAllPromisesRejected()
+    {
+        $expectedException = new class() extends \Exception {
+        };
+
+        $eventLoop = $this->createEventLoop();
+        $promise = $eventLoop->promiseAll(
+            $eventLoop->promiseFulfilled(1),
+            $eventLoop->promiseRejected($expectedException),
+            $eventLoop->promiseFulfilled(2),
+            $eventLoop->promiseRejected(new \Exception())
+        );
+
+        $this->expectException(get_class($expectedException));
+        $eventLoop->wait($promise);
+    }
+}

--- a/tests/EventLoopTest/PromiseRaceTest.php
+++ b/tests/EventLoopTest/PromiseRaceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace M6WebTest\Tornado\EventLoopTest;
+
+use M6Web\Tornado\EventLoop;
+
+trait PromiseRaceTest
+{
+    abstract protected function createEventLoop(): EventLoop;
+
+    public function testPromiseRaceShouldResolveEmptyInput()
+    {
+        $eventLoop = $this->createEventLoop();
+
+        $promise = $eventLoop->promiseRace();
+
+        $this->assertEquals(
+            null,
+            $eventLoop->wait($promise)
+        );
+    }
+
+    public function testPromiseRaceShouldResolvePromisesArray(int $expectedValue = 2)
+    {
+        $eventLoop = $this->createEventLoop();
+        $d1 = $eventLoop->deferred();
+        $d2 = $eventLoop->deferred();
+        $d3 = $eventLoop->deferred();
+
+        // $d2 will be resolved first
+        $eventLoop->async((function () use ($d1, $d2, $d3, $eventLoop) {
+            // Wait some ticks before to resolve the promise
+            yield $eventLoop->idle();
+            yield $eventLoop->idle();
+            $d2->resolve(2);
+
+            // Then, resolve other promises
+            yield $eventLoop->idle();
+            yield $eventLoop->idle();
+            $d1->resolve(1);
+            $d3->resolve(3);
+        })()
+        );
+
+        $promise = $eventLoop->promiseRace(
+            $d1->getPromise(),
+            $d2->getPromise(),
+            $d3->getPromise()
+        );
+
+        $this->assertEquals(
+            $expectedValue,
+            $eventLoop->wait($promise)
+        );
+    }
+
+    public function testPromiseRaceShouldRejectIfFirstSettledPromiseRejects(int $expectedValue = 2)
+    {
+        $eventLoop = $this->createEventLoop();
+        $d1 = $eventLoop->deferred();
+        $d2 = $eventLoop->deferred();
+        $d3 = $eventLoop->deferred();
+
+        // $d2 will be rejected first
+        $eventLoop->async((function () use ($d1, $d2, $d3, $expectedValue, $eventLoop) {
+            // Wait some ticks before to resolve the promise
+            yield $eventLoop->idle();
+            yield $eventLoop->idle();
+            $d2->reject(new \Exception('', 2));
+
+            // Then, resolve other promises
+            yield $eventLoop->idle();
+            yield $eventLoop->idle();
+            $d1->reject(new \Exception('', 1));
+            $d3->reject(new \Exception('', 3));
+        })()
+        );
+
+        $promise = $eventLoop->promiseRace(
+            $d1->getPromise(),
+            $d2->getPromise(),
+            $d3->getPromise()
+        );
+
+        $this->expectExceptionCode($expectedValue);
+        $eventLoop->wait($promise);
+    }
+}


### PR DESCRIPTION
Add the possibility to wait for the first settled promise from a list. Especially useful to create a cancelable promise.

Split tests for promises, and enhance existing ones from ReactPhp use cases.

Close #8 