### PR TITLE
Added basic PhpStan support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,12 @@ php:
   - '7.1'
   - '7.2'
 
-install: composer install
+before_script:
+  - phpenv config-rm xdebug.ini
+  - composer install
+
+env:
+  - TASK=phpunit
+  - TASK=phpstan
+
+script: "composer $TASK"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "m6web/php-cs-fixer-config": "^1.0",
         "ext-curl": "^7.1",
         "react/event-loop": "^1.0",
-        "react/promise": "^2.7"
+        "react/promise": "^2.7",
+        "phpstan/phpstan": "dev-master"
     },
     "suggest": {
         "amphp/amp": "Needed to use Tornado\\Adapter\\Amp\\EventLoop",
@@ -39,5 +40,9 @@
     },
     "config": {
         "bin-dir": "bin/"
+    },
+    "scripts": {
+        "phpunit": "./bin/phpunit",
+        "phpstan": "./bin/phpstan analyse src tests --level=3 --no-progress -vvv"
     }
 }

--- a/src/Adapter/ReactPhp/EventLoop.php
+++ b/src/Adapter/ReactPhp/EventLoop.php
@@ -78,15 +78,11 @@ class EventLoop implements \M6Web\Tornado\EventLoop
                         return $this->deferred->resolve($this->generator->getReturn());
                     }
                     $blockingPromise = $this->generator->current();
-                    self::toReactPromise($blockingPromise)->then([$this, 'onFulfilled'], [$this, 'onRejected']);
+                    Internal\PromiseWrapper::fromPromise($blockingPromise)->getReactPromise()
+                        ->then([$this, 'onFulfilled'], [$this, 'onRejected']);
                 } catch (\Throwable $throwable) {
                     $this->deferred->reject($throwable);
                 }
-            }
-
-            private static function toReactPromise(Promise $promise): \React\Promise\PromiseInterface
-            {
-                return $promise->reactPromise;
             }
         };
 
@@ -228,16 +224,11 @@ class EventLoop implements \M6Web\Tornado\EventLoop
 
     private static function fromReactPromise(\React\Promise\PromiseInterface $reactPromise): Promise
     {
-        $promise = new class() implements Promise {
-            public $reactPromise;
-        };
-        $promise->reactPromise = $reactPromise;
-
-        return $promise;
+        return new Internal\PromiseWrapper($reactPromise);
     }
 
     private static function toReactPromise(Promise $promise): \React\Promise\PromiseInterface
     {
-        return $promise->reactPromise;
+        return Internal\PromiseWrapper::fromPromise($promise)->getReactPromise();
     }
 }

--- a/src/Adapter/ReactPhp/Internal/PromiseWrapper.php
+++ b/src/Adapter/ReactPhp/Internal/PromiseWrapper.php
@@ -22,6 +22,8 @@ class PromiseWrapper implements Promise
 
     public static function fromPromise(Promise $promise): self
     {
+        assert($promise instanceof self);
+
         return $promise;
     }
 

--- a/src/Adapter/ReactPhp/Internal/PromiseWrapper.php
+++ b/src/Adapter/ReactPhp/Internal/PromiseWrapper.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace M6Web\Tornado\Adapter\ReactPhp\Internal;
+
+use M6Web\Tornado\Promise;
+
+/**
+ * @internal
+ * ⚠️ You must NOT rely on this internal implementation
+ */
+class PromiseWrapper implements Promise
+{
+    /**
+     * @var \React\Promise\PromiseInterface
+     */
+    private $reactPromise;
+
+    public function __construct(\React\Promise\PromiseInterface $reactPromise)
+    {
+        $this->reactPromise = $reactPromise;
+    }
+
+    public static function fromPromise(Promise $promise): self
+    {
+        return $promise;
+    }
+
+    public function getReactPromise(): \React\Promise\PromiseInterface
+    {
+        return $this->reactPromise;
+    }
+}

--- a/src/Adapter/Tornado/EventLoop.php
+++ b/src/Adapter/Tornado/EventLoop.php
@@ -259,6 +259,8 @@ class EventLoop implements \M6Web\Tornado\EventLoop
 
     private function toPendingPromise(Promise $promise): Internal\PendingPromise
     {
+        assert($promise instanceof Internal\PendingPromise);
+
         return $promise;
     }
 }

--- a/src/Adapter/Tornado/EventLoop.php
+++ b/src/Adapter/Tornado/EventLoop.php
@@ -87,7 +87,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
         $task->promise = new Internal\PendingPromise();
         $this->tasks[] = $task;
 
-        return $this->fromPendingPromise($task->promise);
+        return $task->promise;
     }
 
     /**
@@ -126,7 +126,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
             $this->async($waitOnePromise($index, $promise));
         }
 
-        return $this->fromPendingPromise($globalPromise);
+        return $globalPromise;
     }
 
     /**
@@ -160,7 +160,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
             $this->async($wrapPromise($promise));
         }
 
-        return $this->fromPendingPromise($globalPromise);
+        return $globalPromise;
     }
 
     /**
@@ -168,7 +168,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseFulfilled($value): Promise
     {
-        return $this->fromPendingPromise((new Internal\PendingPromise())->resolve($value));
+        return (new Internal\PendingPromise())->resolve($value);
     }
 
     /**
@@ -176,7 +176,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseRejected(\Throwable $throwable): Promise
     {
-        return $this->fromPendingPromise((new Internal\PendingPromise())->reject($throwable));
+        return (new Internal\PendingPromise())->reject($throwable);
     }
 
     /**
@@ -236,7 +236,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
             }
         };
         $deferred->internalPromise = new Internal\PendingPromise();
-        $deferred->publicPromise = $this->fromPendingPromise($deferred->internalPromise);
+        $deferred->publicPromise = $deferred->internalPromise;
 
         return $deferred;
     }
@@ -246,9 +246,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function readable($stream): Promise
     {
-        return $this->fromPendingPromise(
-            $this->streamLoop->readable($this, $stream)
-        );
+        return $this->streamLoop->readable($this, $stream);
     }
 
     /**
@@ -256,23 +254,11 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function writable($stream): Promise
     {
-        return $this->fromPendingPromise(
-            $this->streamLoop->writable($this, $stream)
-        );
-    }
-
-    private function fromPendingPromise(Internal\PendingPromise $pendingPromise): Promise
-    {
-        $promise = new class() implements Promise {
-            public $pendingPromise;
-        };
-        $promise->pendingPromise = $pendingPromise;
-
-        return $promise;
+        return $this->streamLoop->writable($this, $stream);
     }
 
     private function toPendingPromise(Promise $promise): Internal\PendingPromise
     {
-        return $promise->pendingPromise;
+        return $promise;
     }
 }

--- a/src/Adapter/Tornado/Internal/PendingPromise.php
+++ b/src/Adapter/Tornado/Internal/PendingPromise.php
@@ -2,11 +2,13 @@
 
 namespace M6Web\Tornado\Adapter\Tornado\Internal;
 
+use M6Web\Tornado\Promise;
+
 /**
  * @internal
  * ⚠️ You must NOT rely on this internal implementation
  */
-class PendingPromise
+class PendingPromise implements Promise
 {
     private $value;
     private $throwable;

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -58,7 +58,7 @@ interface EventLoop
     /**
      * Returns a promise that will be resolved with the input stream when it becomes readable.
      *
-     * @param $stream
+     * @param resource $stream
      *
      * @return Promise
      */
@@ -67,7 +67,7 @@ interface EventLoop
     /**
      * Returns a promise that will be resolved with the input stream when it becomes writable.
      *
-     * @param $stream
+     * @param resource $stream
      *
      * @return Promise
      */

--- a/tests/EventLoopTest/AsyncTest.php
+++ b/tests/EventLoopTest/AsyncTest.php
@@ -83,7 +83,7 @@ trait AsyncTest
     public function testSubGenerators()
     {
         $eventLoop = $this->createEventLoop();
-        $createGenerator = function (Promise ...$promises) use ($eventLoop): \Generator {
+        $createGenerator = function (Promise ...$promises): \Generator {
             $result = [];
             foreach ($promises as $promise) {
                 $result[] = yield $promise;

--- a/tests/EventLoopTest/PromiseRaceTest.php
+++ b/tests/EventLoopTest/PromiseRaceTest.php
@@ -62,7 +62,7 @@ trait PromiseRaceTest
         $d3 = $eventLoop->deferred();
 
         // $d2 will be rejected first
-        $eventLoop->async((function () use ($d1, $d2, $d3, $expectedValue, $eventLoop) {
+        $eventLoop->async((function () use ($d1, $d2, $d3, $eventLoop) {
             // Wait some ticks before to resolve the promise
             yield $eventLoop->idle();
             yield $eventLoop->idle();


### PR DESCRIPTION
Started to fix errors reported by PhpStan, but faced some issues, so we are stuck in level 3 for the moment.

* This PR https://github.com/phpstan/phpstan/pull/1481 is not yet tagged in a release, so we have to use `master` branch
* An issue is pending about closure https://github.com/phpstan/phpstan/issues/1248

Since these errors seems focused on our internal Tornado adapter (not yet production ready), we could choose to discard these classes, in order to increase PhpStan level for other adapters 🤔 