### PR TITLE
Split test suite, and contributing notes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ before_script:
   - composer install
 
 env:
-  - TASK=phpunit
+  - TASK=phpunit-unit
+  - TASK=phpunit-examples
   - TASK=phpstan
 
 script: "composer $TASK"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ before_script:
   - composer install
 
 env:
-  - TASK=phpunit-unit
-  - TASK=phpunit-examples
-  - TASK=phpstan
+  - TASK=tests-unit
+  - TASK=tests-examples
+  - TASK=static-analysis
 
 script: "composer $TASK"

--- a/README.md
+++ b/README.md
@@ -197,3 +197,30 @@ function waitException(Tornado\EventLoop $eventLoop)
 No, even if these two libraries deal with asynchronous programming,
 they are absolutely not related.
 The name *Tornado* has been chosen in reference to the [horse ridden by Zorro](https://en.wikipedia.org/wiki/Tornado_%28horse%29).
+
+## Contributing
+
+Running unit tests:
+```bash
+composer tests-unit
+```
+
+Running examples:
+```bash
+composer tests-examples
+```
+
+Running PhpStan (static analysis):
+```bash
+composer static-analysis
+```
+
+Check code style:
+```bash
+composer code-style-check
+```
+
+Fix code style:
+```bash
+composer code-style-fix
+```

--- a/composer.json
+++ b/composer.json
@@ -42,8 +42,10 @@
         "bin-dir": "bin/"
     },
     "scripts": {
-        "phpunit-unit": "./bin/phpunit --testsuite='Tornado Test Suite'",
-        "phpunit-examples": "./bin/phpunit --testsuite='Tornado Examples'",
-        "phpstan": "./bin/phpstan analyse src tests --level=3 --no-progress -vvv"
+        "tests-unit": "./bin/phpunit --testsuite='Tornado Test Suite'",
+        "tests-examples": "./bin/phpunit --testsuite='Tornado Examples'",
+        "static-analysis": "./bin/phpstan analyse src tests --level=3 --no-progress -vvv",
+        "code-style-check": "./bin/php-cs-fixer fix --dry-run --verbose",
+        "code-style-fix": "./bin/php-cs-fixer fix"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "bin-dir": "bin/"
     },
     "scripts": {
-        "phpunit": "./bin/phpunit",
+        "phpunit-unit": "./bin/phpunit --testsuite='Tornado Test Suite'",
+        "phpunit-examples": "./bin/phpunit --testsuite='Tornado Examples'",
         "phpstan": "./bin/phpstan analyse src tests --level=3 --no-progress -vvv"
     }
 }

--- a/examples/tests/ExamplesTest.php
+++ b/examples/tests/ExamplesTest.php
@@ -10,11 +10,15 @@ class ExamplesTest extends TestCase
     {
         $iterator = new \FilesystemIterator(
             __DIR__.'/../',
-            \FilesystemIterator::CURRENT_AS_PATHNAME | \FilesystemIterator::KEY_AS_FILENAME | \FilesystemIterator::SKIP_DOTS
+            \FilesystemIterator::CURRENT_AS_FILEINFO | \FilesystemIterator::KEY_AS_FILENAME | \FilesystemIterator::SKIP_DOTS
         );
 
-        foreach ($iterator as $name => $path) {
-            yield $name => [$path];
+        foreach ($iterator as $name => $fileinfo) {
+            if ($fileinfo->isDir()) {
+                continue;
+            }
+
+            yield $name => [$fileinfo->getRealPath()];
         }
     }
 

--- a/examples/tests/ExamplesTest.php
+++ b/examples/tests/ExamplesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace M6WebTest\Tornado;
+namespace M6WebExamplesTest\Tornado;
 
 use PHPUnit\Framework\TestCase;
 
@@ -9,7 +9,7 @@ class ExamplesTest extends TestCase
     public function examplesProvider()
     {
         $iterator = new \FilesystemIterator(
-            __DIR__.'/../examples',
+            __DIR__.'/../',
             \FilesystemIterator::CURRENT_AS_PATHNAME | \FilesystemIterator::KEY_AS_FILENAME | \FilesystemIterator::SKIP_DOTS
         );
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,6 +19,9 @@
         <testsuite name="Tornado Test Suite">
             <directory>tests</directory>
         </testsuite>
+        <testsuite name="Tornado Examples">
+            <directory>examples/tests</directory>
+        </testsuite>
     </testsuites>
 
     <filter>


### PR DESCRIPTION
Because examples can be long to run (and that's the expected behavior, so now they are in a dedicated test suite.
Added some specific commands (via composer) to ease contributing.
Examples tests are run in parallel during Travis Build.