### PR TITLE
Fixed inconsistent behavior with wait function

### DIFF
--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -12,7 +12,20 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function wait(Promise $promise)
     {
-        return \Amp\Promise\wait(self::toAmpPromise($promise));
+        try {
+            return \Amp\Promise\wait(self::toAmpPromise($promise));
+        } catch (\Error $error) {
+            // Modify exceptions sent by Amp itself
+            if ($error->getCode() !== 0) {
+                throw $error;
+            }
+            switch ($error->getMessage()) {
+                case 'Loop stopped without resolving the promise':
+                    throw new \Error('Impossible to resolve the promise, no more task to execute.', 0, $error);
+                default:
+                    throw $error;
+            }
+        }
     }
 
     /**

--- a/src/Adapter/Tornado/EventLoop.php
+++ b/src/Adapter/Tornado/EventLoop.php
@@ -24,12 +24,14 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     public function wait(Promise $promise)
     {
         $promiseIsPending = true;
-        $finalAction = function () {throw new \LogicException('Cannot resolve waited promise.'); };
+        $finalAction = function () {throw new \Error('Impossible to resolve the promise, no more task to execute..'); };
         $this->toPendingPromise($promise)->addCallbacks(
-            function ($value) use (&$finalAction) {
+            function ($value) use (&$finalAction, &$promiseIsPending) {
+                $promiseIsPending = false;
                 $finalAction = function () use ($value) {return $value; };
             },
-            function (\Throwable $throwable) use (&$finalAction) {
+            function (\Throwable $throwable) use (&$finalAction, &$promiseIsPending) {
+                $promiseIsPending = false;
                 $finalAction = function () use ($throwable) {throw $throwable; };
             }
         );

--- a/src/Adapter/Tornado/SynchronousEventLoop.php
+++ b/src/Adapter/Tornado/SynchronousEventLoop.php
@@ -133,7 +133,7 @@ class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
             public function getPromise(): Promise
             {
                 if (!$this->promise) {
-                    throw new \LogicException('Synchronous Deferred must be resolved/rejected before to retrieve its promise.');
+                    throw new \Error('Synchronous Deferred must be resolved/rejected before to retrieve its promise.');
                 }
 
                 return $this->promise;

--- a/tests/Adapter/Tornado/SynchronousEventLoopTest.php
+++ b/tests/Adapter/Tornado/SynchronousEventLoopTest.php
@@ -53,4 +53,21 @@ class SynchronousEventLoopTest extends \M6WebTest\Tornado\EventLoopTest
         // In these conditions, we should be close of the expected delay
         $this->assertLessThanOrEqual($expectedDelay + 10, $duration);
     }
+
+    public function testWaitFunctionShouldReturnAsSoonAsPromiseIsResolved()
+    {
+        // By definition, synchronous event loop can only wait a promise if already resolved.
+        // So this use case is not relevant for this particular implementation.
+        $this->assertTrue(true);
+    }
+
+    public function testWaitFunctionShouldThrowIfPromiseCannotBeResolved()
+    {
+        $eventLoop = $this->createEventLoop();
+        $deferred = $eventLoop->deferred();
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Synchronous Deferred must be resolved/rejected before to retrieve its promise.');
+        $eventLoop->wait($deferred->getPromise());
+    }
 }


### PR DESCRIPTION
Fixed some bugs found thanks to PhpStan in #16 

* The `wait` function must return as soon as the promise is resolved/rejected, even if there are some other pending asynchronous functions.
* If there are no more functions to execute and that the waited promise is still not resolved/rejected, an exception must be thrown.

By design, the `SynchronousEventLoop` is not really concerned by these use cases as usual.