### PR TITLE
Added EventLoop::promiseForeach

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ it will be more efficient to use [`EventLoop::promiseAll`](src/EventLoop.php)
 instead of waiting each input [`Promise`](src/Promise.php) consecutively,
 because of concurrency.
 Each time that you have several promises to resolve,
-ask yourself if you could wait them concurrently, especially when you deal with `foreach` loops. 
+ask yourself if you could wait them concurrently, especially when you deal with loops
+(take a look to [`EventLoop::promiseForeach`](src/EventLoop.php) function). 
 
 ### Resolving your own promises
 By design, you cannot resolve a promise by yourself, you will need a [`Deferred`](src/Deferred.php).

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -73,6 +73,19 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     /**
      * {@inheritdoc}
      */
+    public function promiseForeach($traversable, callable $function): Promise
+    {
+        $ampPromises = [];
+        foreach ($traversable as $key => $value) {
+            $ampPromises[] = self::toAmpPromise($this->async($function($value, $key)));
+        }
+
+        return self::fromAmpPromise(\Amp\Promise\all($ampPromises));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function promiseRace(Promise ...$promises): Promise
     {
         if (empty($promises)) {

--- a/src/Adapter/ReactPhp/EventLoop.php
+++ b/src/Adapter/ReactPhp/EventLoop.php
@@ -116,6 +116,19 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     /**
      * {@inheritdoc}
      */
+    public function promiseForeach($traversable, callable $function): Promise
+    {
+        $reactPromises = [];
+        foreach ($traversable as $key => $value) {
+            $reactPromises[] = self::toReactPromise($this->async($function($value, $key)));
+        }
+
+        return self::fromReactPromise(\React\Promise\all($reactPromises));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function promiseRace(Promise ...$promises): Promise
     {
         $reactPromises = array_map([self::class, 'toReactPromise'], $promises);

--- a/src/Adapter/Tornado/EventLoop.php
+++ b/src/Adapter/Tornado/EventLoop.php
@@ -134,6 +134,19 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     /**
      * {@inheritdoc}
      */
+    public function promiseForeach($traversable, callable $function): Promise
+    {
+        $promises = [];
+        foreach ($traversable as $key => $value) {
+            $promises[] = $this->async($function($value, $key));
+        }
+
+        return $this->promiseAll(...$promises);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function promiseRace(Promise ...$promises): Promise
     {
         if (empty($promises)) {

--- a/src/Adapter/Tornado/SynchronousEventLoop.php
+++ b/src/Adapter/Tornado/SynchronousEventLoop.php
@@ -70,6 +70,23 @@ class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
     /**
      * {@inheritdoc}
      */
+    public function promiseForeach($traversable, callable $function): Promise
+    {
+        try {
+            $results = [];
+            foreach ($traversable as $key => $value) {
+                $results[] = $this->wait($this->async($function($value, $key)));
+            }
+
+            return $this->promiseFulfilled($results);
+        } catch (\Throwable $exception) {
+            return $this->promiseRejected($exception);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function promiseRace(Promise ...$promises): Promise
     {
         return reset($promises) ?: $this->promiseFulfilled(null);

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -24,6 +24,18 @@ interface EventLoop
     public function promiseAll(Promise ...$promises): Promise;
 
     /**
+     * Creates a Promise that will be resolved with an array containing the result of
+     * $function applied to each elements of input traversable.
+     * You should use this function each time that you use yield in a foreach loop.
+     *
+     * @param \Traversable|array $traversable Input elements
+     * @param callable           $function    must return a generator from an input value, and an optional key
+     *
+     * @return Promise
+     */
+    public function promiseForeach($traversable, callable $function): Promise;
+
+    /**
      * Creates a promise that will behave like the first settled input promise, while others will be ignored.
      **/
     public function promiseRace(Promise ...$promises): Promise;

--- a/tests/EventLoopTest.php
+++ b/tests/EventLoopTest.php
@@ -13,6 +13,7 @@ abstract class EventLoopTest extends TestCase
         EventLoopTest\AsyncTest,
         EventLoopTest\StreamsTest,
         EventLoopTest\PromiseAllTest,
+        EventLoopTest\PromiseForeachTest,
         EventLoopTest\PromiseRaceTest;
 
     abstract protected function createEventLoop(): EventLoop;

--- a/tests/EventLoopTest/PromiseForeachTest.php
+++ b/tests/EventLoopTest/PromiseForeachTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace M6WebTest\Tornado\EventLoopTest;
+
+use M6Web\Tornado\EventLoop;
+
+trait PromiseForeachTest
+{
+    abstract protected function createEventLoop(): EventLoop;
+
+    /**
+     * Helper function to test that promiseForeach works for array AND iterator inputs.
+     */
+    private function assertSameForeach(EventLoop $eventLoop, array $input, callable $callback, array $expected)
+    {
+        $this->assertSame(
+            $expected,
+            $eventLoop->wait($eventLoop->promiseForeach($input, $callback))
+        );
+
+        $this->assertSame(
+            $expected,
+            $eventLoop->wait($eventLoop->promiseForeach(new \ArrayIterator($input), $callback))
+        );
+    }
+
+    public function testPromiseForeachAcceptsEmptyTraversable()
+    {
+        $eventLoop = $this->createEventLoop();
+        $callback = function () {
+            throw new \Exception("Shouldn't be reached!");
+        };
+
+        $this->assertSameForeach($eventLoop, [], $callback, []);
+    }
+
+    public function testPromiseForeachShouldThrowIfCallbackDoesNotReturnGenerator()
+    {
+        $eventLoop = $this->createEventLoop();
+        $callback = function () {
+            return;
+        };
+
+        $this->expectException(\TypeError::class);
+        $eventLoop->wait(
+            $eventLoop->promiseForeach([1], $callback)
+        );
+    }
+
+    public function testPromiseForeachWithCallbackUsingValueOnly()
+    {
+        $eventLoop = $this->createEventLoop();
+        $callback = function ($value) use ($eventLoop) {
+            yield $eventLoop->idle();
+
+            return $value;
+        };
+        $input = range(1, 10);
+
+        $this->assertSameForeach($eventLoop, $input, $callback, $input);
+    }
+
+    public function testPromiseForeachWithCallbackUsingValueAndKey()
+    {
+        $eventLoop = $this->createEventLoop();
+        $callback = function ($value, $key) use ($eventLoop) {
+            yield $eventLoop->idle();
+
+            return [$key, $value];
+        };
+        $input = ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4];
+
+        $this->assertSameForeach($eventLoop, $input, $callback, array_map(
+            null, array_keys($input), $input
+        ));
+    }
+
+    public function testPromiseForeachPropagateThrownExceptions()
+    {
+        $eventLoop = $this->createEventLoop();
+        $exception = new \LogicException();
+        $callback = function ($value) use ($eventLoop, $exception) {
+            yield $eventLoop->idle();
+            throw $exception;
+        };
+
+        $this->expectExceptionObject($exception);
+        $eventLoop->wait(
+            $eventLoop->promiseForeach([1], $callback)
+        );
+    }
+}


### PR DESCRIPTION
Allows to rewrite [example 3](https://github.com/M6Web/Tornado/blob/master/examples/03-http-client.php) like this

```php
$urls = ['http://httpbin.org/status/404', 'http://www.google.com', 'http://www.example.com'];
$results = $eventLoop->wait(
        $eventLoop->promiseForeach($urls, function($url) use($httpClient) {
            // Let's use Guzzle Psr7 implementation
            $request = new \GuzzleHttp\Psr7\Request('GET', $url);

            $start = microtime(true);
            /** @var \Psr\Http\Message\ResponseInterface */
            $response = yield $httpClient->sendRequest($request);
            $duration = microtime(true) - $start;

            return "[{$response->getStatusCode()}]\t $url\t\t $duration";
        })
);
```