### PR TITLE
Internal refactoring to ease maintainability

### DIFF
--- a/src/Adapter/Amp/Internal/Deferred.php
+++ b/src/Adapter/Amp/Internal/Deferred.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace M6Web\Tornado\Adapter\Amp\Internal;
+
+use M6Web\Tornado\Promise;
+
+/**
+ * @internal
+ * ⚠️ You must NOT rely on this internal implementation
+ */
+class Deferred implements \M6Web\Tornado\Deferred
+{
+    /**
+     * @var \Amp\Deferred
+     */
+    private $ampDeferred;
+
+    /**
+     * @var PromiseWrapper
+     */
+    private $promise;
+
+    public function __construct()
+    {
+        $this->ampDeferred = new \Amp\Deferred();
+        $this->promise = new PromiseWrapper($this->ampDeferred->promise());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPromise(): Promise
+    {
+        return $this->promise;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve($value)
+    {
+        $this->ampDeferred->resolve($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reject(\Throwable $throwable)
+    {
+        $this->ampDeferred->fail($throwable);
+    }
+}

--- a/src/Adapter/Amp/Internal/PromiseWrapper.php
+++ b/src/Adapter/Amp/Internal/PromiseWrapper.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace M6Web\Tornado\Adapter\Amp\Internal;
+
+use M6Web\Tornado\Promise;
+
+/**
+ * @internal
+ * ⚠️ You must NOT rely on this internal implementation
+ */
+class PromiseWrapper implements Promise
+{
+    /**
+     * @var \Amp\Promise
+     */
+    private $ampPromise;
+
+    public function __construct(\Amp\Promise $ampPromise)
+    {
+        $this->ampPromise = $ampPromise;
+    }
+
+    public function getAmpPromise(): \Amp\Promise
+    {
+        return $this->ampPromise;
+    }
+
+    public static function downcast(Promise $promise): self
+    {
+        assert($promise instanceof self, new \Error('Input promise was not created by this adapter.'));
+
+        return $promise;
+    }
+
+    public static function fromGenerator(\Generator $generator): self
+    {
+        $promise = $generator->current();
+        if (!$promise instanceof self) {
+            throw new \Error('Asynchronous function is yielding a ['.gettype($promise).'] instead of a Promise.');
+        }
+
+        return self::downcast($promise);
+    }
+
+    /**
+     * @param Promise[] ...$promises
+     *
+     * @return \Amp\Promise[]
+     */
+    public static function toAmpPromiseArray(Promise ...$promises): array
+    {
+        return array_map(function (Promise $promise) {
+            return self::downcast($promise)->ampPromise;
+        }, $promises);
+    }
+}

--- a/src/Adapter/ReactPhp/Internal/Deferred.php
+++ b/src/Adapter/ReactPhp/Internal/Deferred.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace M6Web\Tornado\Adapter\ReactPhp\Internal;
+
+use M6Web\Tornado\Promise;
+
+/**
+ * @internal
+ * ⚠️ You must NOT rely on this internal implementation
+ */
+class Deferred implements \M6Web\Tornado\Deferred
+{
+    /**
+     * @var \React\Promise\Deferred
+     */
+    private $reactDeferred;
+
+    /**
+     * @var PromiseWrapper
+     */
+    private $promise;
+
+    public function __construct()
+    {
+        $this->reactDeferred = new \React\Promise\Deferred();
+        $this->promise = new PromiseWrapper($this->reactDeferred->promise());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPromise(): Promise
+    {
+        return $this->promise;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve($value)
+    {
+        $this->reactDeferred->resolve($value);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reject(\Throwable $throwable)
+    {
+        $this->reactDeferred->reject($throwable);
+    }
+}

--- a/src/Adapter/Tornado/Internal/Deferred.php
+++ b/src/Adapter/Tornado/Internal/Deferred.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace M6Web\Tornado\Adapter\Tornado\Internal;
+
+use M6Web\Tornado\Promise;
+
+/**
+ * @internal
+ * ⚠️ You must NOT rely on this internal implementation
+ */
+class Deferred implements \M6Web\Tornado\Deferred
+{
+    /**
+     * @var PendingPromise
+     */
+    private $promise;
+
+    public function __construct()
+    {
+        $this->promise = new PendingPromise();
+    }
+
+    public function getPromise(): Promise
+    {
+        return $this->promise;
+    }
+
+    public function resolve($value)
+    {
+        $this->promise->resolve($value);
+    }
+
+    public function reject(\Throwable $throwable)
+    {
+        $this->promise->reject($throwable);
+    }
+}

--- a/src/Adapter/Tornado/Internal/PendingPromise.php
+++ b/src/Adapter/Tornado/Internal/PendingPromise.php
@@ -15,6 +15,23 @@ class PendingPromise implements Promise
     private $callbacks = [];
     private $isSettled = false;
 
+    public static function downcast(Promise $promise): self
+    {
+        assert($promise instanceof self, new \Error('Input promise was not created by this adapter.'));
+
+        return $promise;
+    }
+
+    public static function fromGenerator(\Generator $generator): self
+    {
+        $promise = $generator->current();
+        if (!$promise instanceof self) {
+            throw new \Error('Asynchronous function is yielding a ['.gettype($promise).'] instead of a Promise.');
+        }
+
+        return self::downcast($promise);
+    }
+
     public function resolve($value): self
     {
         $this->settle();

--- a/src/Adapter/Tornado/SynchronousEventLoop.php
+++ b/src/Adapter/Tornado/SynchronousEventLoop.php
@@ -34,6 +34,10 @@ class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
             while ($generator->valid()) {
                 $blockingPromise = $generator->current();
 
+                if (!$blockingPromise instanceof Promise) {
+                    throw new \Error('Asynchronous function is yielding a ['.gettype($blockingPromise).'] instead of a Promise.');
+                }
+
                 // Resolves blocking promise and forwards result to the generator
                 $blockingPromiseValue = null;
                 $blockingPromiseException = null;

--- a/tests/EventLoopTest/AsyncTest.php
+++ b/tests/EventLoopTest/AsyncTest.php
@@ -42,6 +42,20 @@ trait AsyncTest
         $eventLoop->wait($promise);
     }
 
+    public function testYieldingInvalidValueMayThrowAnError()
+    {
+        $createGenerator = function (): \Generator {
+            yield 'Something that is not a promise.';
+        };
+
+        $eventLoop = $this->createEventLoop();
+        $promise = $eventLoop->async($createGenerator());
+
+        $this->expectException(\Error::class);
+        $this->expectExceptionMessage('Asynchronous function is yielding a [string] instead of a Promise.');
+        $eventLoop->wait($promise);
+    }
+
     public function testYieldingGenerator()
     {
         $createGenerator = function (EventLoop $eventLoop, $a, $b, $c): \Generator {


### PR DESCRIPTION
My initial attempt was to use anonymous class to prevent Tornado users to use internal classes, but it was really messy, and prevented to use clean types everywhere (especially to increase PhpStan level #16 ).
So, to improve maintainability, I preferred to write explicit classes, in an `Internal` namespace to discourage users to use them. Will also help to solve #14 .
I added a small test to ensure that behavior is the same everywhere if we yield something that is not a `Promise`.