### PR TITLE
Throwing exceptions from background asynchronous functions

### DIFF
--- a/src/Adapter/Amp/Internal/Deferred.php
+++ b/src/Adapter/Amp/Internal/Deferred.php
@@ -34,6 +34,11 @@ class Deferred implements \M6Web\Tornado\Deferred
         return $this->promise;
     }
 
+    public function getPromiseWrapper(): PromiseWrapper
+    {
+        return $this->promise;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Adapter/Amp/Internal/PromiseWrapper.php
+++ b/src/Adapter/Amp/Internal/PromiseWrapper.php
@@ -15,6 +15,8 @@ class PromiseWrapper implements Promise
      */
     private $ampPromise;
 
+    private $hasBeenYielded = false;
+
     public function __construct(\Amp\Promise $ampPromise)
     {
         $this->ampPromise = $ampPromise;
@@ -38,8 +40,15 @@ class PromiseWrapper implements Promise
         if (!$promise instanceof self) {
             throw new \Error('Asynchronous function is yielding a ['.gettype($promise).'] instead of a Promise.');
         }
+        $promise = self::downcast($promise);
+        $promise->hasBeenYielded = true;
 
-        return self::downcast($promise);
+        return $promise;
+    }
+
+    public function hasBeenYielded(): bool
+    {
+        return $this->hasBeenYielded;
     }
 
     /**

--- a/src/Adapter/ReactPhp/Internal/Deferred.php
+++ b/src/Adapter/ReactPhp/Internal/Deferred.php
@@ -34,6 +34,11 @@ class Deferred implements \M6Web\Tornado\Deferred
         return $this->promise;
     }
 
+    public function getPromiseWrapper(): PromiseWrapper
+    {
+        return $this->promise;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Adapter/ReactPhp/Internal/PromiseWrapper.php
+++ b/src/Adapter/ReactPhp/Internal/PromiseWrapper.php
@@ -15,6 +15,8 @@ class PromiseWrapper implements Promise
      */
     private $reactPromise;
 
+    private $hasBeenYielded = false;
+
     public function __construct(\React\Promise\PromiseInterface $reactPromise)
     {
         $this->reactPromise = $reactPromise;
@@ -39,7 +41,15 @@ class PromiseWrapper implements Promise
             throw new \Error('Asynchronous function is yielding a ['.gettype($promise).'] instead of a Promise.');
         }
 
-        return self::downcast($promise);
+        $promise = self::downcast($promise);
+        $promise->hasBeenYielded = true;
+
+        return $promise;
+    }
+
+    public function hasBeenYielded(): bool
+    {
+        return $this->hasBeenYielded;
     }
 
     /**

--- a/src/Adapter/Tornado/Internal/PendingPromise.php
+++ b/src/Adapter/Tornado/Internal/PendingPromise.php
@@ -14,6 +14,7 @@ class PendingPromise implements Promise
     private $throwable;
     private $callbacks = [];
     private $isSettled = false;
+    private $hasBeenYielded = false;
 
     public static function downcast(Promise $promise): self
     {
@@ -29,7 +30,15 @@ class PendingPromise implements Promise
             throw new \Error('Asynchronous function is yielding a ['.gettype($promise).'] instead of a Promise.');
         }
 
-        return self::downcast($promise);
+        $promise = self::downcast($promise);
+        $promise->hasBeenYielded = true;
+
+        return $promise;
+    }
+
+    public function hasBeenYielded(): bool
+    {
+        return $this->hasBeenYielded;
     }
 
     public function resolve($value): self

--- a/src/Adapter/Tornado/Internal/Task.php
+++ b/src/Adapter/Tornado/Internal/Task.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace M6Web\Tornado\Adapter\Tornado\Internal;
+
+/**
+ * @internal
+ * ⚠️ You must NOT rely on this internal implementation
+ */
+class Task
+{
+    private $generator;
+    private $promise;
+
+    public function __construct(\Generator $generator)
+    {
+        $this->generator = $generator;
+        $this->promise = new PendingPromise();
+    }
+
+    public function getPromise(): PendingPromise
+    {
+        return $this->promise;
+    }
+
+    public function getGenerator(): \Generator
+    {
+        return $this->generator;
+    }
+}

--- a/tests/Adapter/Amp/EventLoopTest.php
+++ b/tests/Adapter/Amp/EventLoopTest.php
@@ -11,4 +11,10 @@ class EventLoopTest extends \M6WebTest\Tornado\EventLoopTest
     {
         return new Amp\EventLoop();
     }
+
+    public function testStreamShouldReadFromWritable($expectedSequence = '')
+    {
+        // Because Amp resolve promises in a slightly different order.
+        parent::testStreamShouldReadFromWritable('W0R0W12345R12R34W6R56R');
+    }
 }

--- a/tests/Adapter/ReactPhp/EventLoopTest.php
+++ b/tests/Adapter/ReactPhp/EventLoopTest.php
@@ -12,10 +12,4 @@ class EventLoopTest extends \M6WebTest\Tornado\EventLoopTest
     {
         return new ReactPhp\EventLoop(new StreamSelectLoop());
     }
-
-    public function testStreamShouldReadFromWritable($expectedSequence = '')
-    {
-        // Because ReactPhp resolve promise in a slightly different order.
-        parent::testStreamShouldReadFromWritable('W0R0W12345R12W6R34R56R');
-    }
 }

--- a/tests/EventLoopTest/StreamsTest.php
+++ b/tests/EventLoopTest/StreamsTest.php
@@ -31,7 +31,7 @@ trait StreamsTest
         return $sockets;
     }
 
-    public function testStreamShouldReadFromWritable($expectedSequence = 'W0R0W12345R12R34W6R56R')
+    public function testStreamShouldReadFromWritable($expectedSequence = 'W0R0W12345R12W6R34R56R')
     {
         $tokens = ['0', '12345', '6'];
         [$streamIn, $streamOut] = $this->createStreamPair();


### PR DESCRIPTION
Before this PR, if you executed something like this
```php
$ignoredPromise = $eventLoop->async(throwingGenerator());
$eventLoop->wait($eventLoop->async(successGenerator());
```
No errors were reported, since nobody was looking at `$ignoredPromise` result.
Now, **by default**, the `wait` function will rethrow uncaught exceptions of asynchronous functions. If you want to explicitly ignore some of these exceptions, explicitly catch them and ignore them with something like that:
```php
$ignoredPromise = $eventLoop->async(function() {
  try {
    yield from throwingGenerator();
  } catch(\Throwable $throwable) {
      // I want to ignore all exceptions for this function
  }
});
```

Fix #14 