### PR TITLE
fix: promise{All,Foreach,Race} child promises are considered yielded

### DIFF
--- a/src/Adapter/Amp/Internal/PromiseWrapper.php
+++ b/src/Adapter/Amp/Internal/PromiseWrapper.php
@@ -56,10 +56,13 @@ class PromiseWrapper implements Promise
      *
      * @return \Amp\Promise[]
      */
-    public static function toAmpPromiseArray(Promise ...$promises): array
+    public static function toYieldedAmpPromiseArray(Promise ...$promises): array
     {
         return array_map(function (Promise $promise) {
-            return self::downcast($promise)->ampPromise;
+            $promise = self::downcast($promise);
+            $promise->hasBeenYielded = true;
+
+            return $promise->ampPromise;
         }, $promises);
     }
 }

--- a/src/Adapter/ReactPhp/EventLoop.php
+++ b/src/Adapter/ReactPhp/EventLoop.php
@@ -2,7 +2,6 @@
 
 namespace M6Web\Tornado\Adapter\ReactPhp;
 
-use M6Web\Tornado\Adapter\ReactPhp\Internal\PromiseWrapper;
 use M6Web\Tornado\Deferred;
 use M6Web\Tornado\Promise;
 
@@ -111,7 +110,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     public function promiseAll(Promise ...$promises): Promise
     {
         return new Internal\PromiseWrapper(\React\Promise\all(
-            Internal\PromiseWrapper::toReactPromiseArray(...$promises)
+            Internal\PromiseWrapper::toYieldedReactPromiseArray(...$promises)
         ));
     }
 
@@ -120,14 +119,12 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseForeach($traversable, callable $function): Promise
     {
-        $reactPromises = [];
+        $promises = [];
         foreach ($traversable as $key => $value) {
-            $reactPromises[] = Internal\PromiseWrapper::downcast(
-                $this->async($function($value, $key))
-            )->getReactPromise();
+            $promises[] = $this->async($function($value, $key));
         }
 
-        return new PromiseWrapper(\React\Promise\all($reactPromises));
+        return $this->promiseAll(...$promises);
     }
 
     /**
@@ -136,7 +133,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     public function promiseRace(Promise ...$promises): Promise
     {
         return new Internal\PromiseWrapper(\React\Promise\race(
-            Internal\PromiseWrapper::toReactPromiseArray(...$promises)
+            Internal\PromiseWrapper::toYieldedReactPromiseArray(...$promises)
         ));
     }
 

--- a/src/Adapter/ReactPhp/Internal/PromiseWrapper.php
+++ b/src/Adapter/ReactPhp/Internal/PromiseWrapper.php
@@ -57,10 +57,13 @@ class PromiseWrapper implements Promise
      *
      * @return \React\Promise\PromiseInterface[]
      */
-    public static function toReactPromiseArray(Promise ...$promises): array
+    public static function toYieldedReactPromiseArray(Promise ...$promises): array
     {
         return array_map(function (Promise $promise) {
-            return self::downcast($promise)->reactPromise;
+            $promise = self::downcast($promise);
+            $promise->hasBeenYielded = true;
+
+            return $promise->reactPromise;
         }, $promises);
     }
 }

--- a/tests/EventLoopTest/PromiseAllTest.php
+++ b/tests/EventLoopTest/PromiseAllTest.php
@@ -74,4 +74,27 @@ trait PromiseAllTest
             $eventLoop->wait($promise)
         );
     }
+
+    public function testPromiseAllCatchableException()
+    {
+        $eventLoop = $this->createEventLoop();
+
+        $throwingGenerator = (function () use ($eventLoop): \Generator {
+            yield $eventLoop->idle();
+            throw new \Exception('This is a failure');
+        })();
+
+        $createGenerator = function () use ($eventLoop, $throwingGenerator): \Generator {
+            try {
+                yield $eventLoop->promiseAll($eventLoop->async($throwingGenerator));
+            } catch (\Exception $e) {
+                return 'catched!';
+            }
+        };
+
+        $this->assertSame(
+            'catched!',
+            $eventLoop->wait($eventLoop->async($createGenerator()))
+        );
+    }
 }

--- a/tests/EventLoopTest/PromiseForeachTest.php
+++ b/tests/EventLoopTest/PromiseForeachTest.php
@@ -89,4 +89,24 @@ trait PromiseForeachTest
             $eventLoop->promiseForeach([1], $callback)
         );
     }
+
+    public function testPromiseForeachCatchableException()
+    {
+        $eventLoop = $this->createEventLoop();
+        $createGenerator = function () use ($eventLoop): \Generator {
+            try {
+                yield $eventLoop->promiseForeach([1], function ($value) use ($eventLoop) {
+                    yield $eventLoop->idle();
+                    throw new \Exception('This is a failure');
+                });
+            } catch (\Exception $e) {
+                return 'catched';
+            }
+        };
+
+        $this->assertSame(
+            'catched',
+            $eventLoop->wait($eventLoop->async($createGenerator()))
+        );
+    }
 }


### PR DESCRIPTION
When an exception is thrown while resolving child promises of grouped promise (all, foreach, race) with react and amp driver, it is not catchable with a try-catch block enclosing yielding the promise.

Promises passed to \React\Promise\{all,race} or \Amp\Promise\all are not managed directly by tornado and cannot be marked as yielded when they are retrieved, so exception thrown while resolving them are considered _unmanaged_ and thrown from the eventloop at the next tick.

Mark all promises as yielded before passing them to grouping methods so tornado knows they are actually managed.