### PR TITLE
fix: defer throwing unmanaged defered generator exception to promise destructor

### DIFF
--- a/src/Adapter/Amp/Internal/Deferred.php
+++ b/src/Adapter/Amp/Internal/Deferred.php
@@ -26,6 +26,14 @@ class Deferred implements \M6Web\Tornado\Deferred
         $this->promise = new PromiseWrapper($this->ampDeferred->promise());
     }
 
+    public static function forAsync(): self
+    {
+        $self = new self();
+        $self->promise->enableThrowOnDestructIfNotYielded();
+
+        return $self;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Adapter/ReactPhp/Internal/Deferred.php
+++ b/src/Adapter/ReactPhp/Internal/Deferred.php
@@ -26,6 +26,14 @@ class Deferred implements \M6Web\Tornado\Deferred
         $this->promise = new PromiseWrapper($this->reactDeferred->promise());
     }
 
+    public static function forAsync(): self
+    {
+        $self = new self();
+        $self->promise->enableThrowOnDestructIfNotYielded();
+
+        return $self;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Adapter/Tornado/EventLoop.php
+++ b/src/Adapter/Tornado/EventLoop.php
@@ -86,7 +86,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
                         $fnSafeGeneratorCallback($task, 'throw')
                     );
                 } catch (\Throwable $exception) {
-                    $task->getPromise()->throwOnDestructIfNotYielded($exception);
+                    $task->getPromise()->enableThrowOnDestructIfNotYielded();
                     $task->getPromise()->reject($exception);
                 }
 

--- a/src/Adapter/Tornado/EventLoop.php
+++ b/src/Adapter/Tornado/EventLoop.php
@@ -29,7 +29,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     {
         $promiseIsPending = true;
         $finalAction = function () {throw new \Error('Impossible to resolve the promise, no more task to execute..'); };
-        Internal\PendingPromise::downcast($promise)->addCallbacks(
+        Internal\PendingPromise::toWatchedPromise($promise)->addCallbacks(
             function ($value) use (&$finalAction, &$promiseIsPending) {
                 $promiseIsPending = false;
                 $finalAction = function () use ($value) {return $value; };
@@ -86,11 +86,8 @@ class EventLoop implements \M6Web\Tornado\EventLoop
                         $fnSafeGeneratorCallback($task, 'throw')
                     );
                 } catch (\Throwable $exception) {
-                    if ($task->getPromise()->hasBeenYielded()) {
-                        $task->getPromise()->reject($exception);
-                    } else {
-                        throw $exception;
-                    }
+                    $task->getPromise()->throwOnDestructIfNotYielded($exception);
+                    $task->getPromise()->reject($exception);
                 }
 
                 $fnThrowIfNotNull($globalException);

--- a/src/Adapter/Tornado/Internal/PendingPromise.php
+++ b/src/Adapter/Tornado/Internal/PendingPromise.php
@@ -15,10 +15,31 @@ class PendingPromise implements Promise
     private $callbacks = [];
     private $isSettled = false;
     private $hasBeenYielded = false;
+    private $exception;
+
+    public function __destruct()
+    {
+        if (!$this->hasBeenYielded && $this->exception) {
+            throw $this->exception;
+        }
+    }
+
+    public function throwOnDestructIfNotYielded(\Throwable $throwable)
+    {
+        $this->exception = $throwable;
+    }
 
     public static function downcast(Promise $promise): self
     {
         assert($promise instanceof self, new \Error('Input promise was not created by this adapter.'));
+
+        return $promise;
+    }
+
+    public static function toWatchedPromise(Promise $promise): self
+    {
+        $promise = self::downcast($promise);
+        $promise->hasBeenYielded = true;
 
         return $promise;
     }

--- a/src/Adapter/Tornado/Internal/PendingPromise.php
+++ b/src/Adapter/Tornado/Internal/PendingPromise.php
@@ -15,18 +15,18 @@ class PendingPromise implements Promise
     private $callbacks = [];
     private $isSettled = false;
     private $hasBeenYielded = false;
-    private $exception;
+    private $throwOnDestructIfNotYielded = false;
 
     public function __destruct()
     {
-        if (!$this->hasBeenYielded && $this->exception) {
-            throw $this->exception;
+        if ($this->throwOnDestructIfNotYielded && !$this->hasBeenYielded && $this->throwable) {
+            throw $this->throwable;
         }
     }
 
-    public function throwOnDestructIfNotYielded(\Throwable $throwable)
+    public function enableThrowOnDestructIfNotYielded()
     {
-        $this->exception = $throwable;
+        $this->throwOnDestructIfNotYielded = true;
     }
 
     public static function downcast(Promise $promise): self

--- a/tests/EventLoopTest/AsyncTest.php
+++ b/tests/EventLoopTest/AsyncTest.php
@@ -227,12 +227,13 @@ trait AsyncTest
             yield $eventLoop->idle();
         };
 
-        $ignoredBackgroundPromise = $eventLoop->async($failingGenerator());
+        $eventLoop->async($failingGenerator());
         $promiseSuccess = $eventLoop->async($waitingGenerator());
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('This is a failure');
         $eventLoop->wait($promiseSuccess);
+        gc_collect_cycles();
     }
 
     public function testEventLoopShouldNotThrowInCaseOfExplicitlyRejectedPromise()


### PR DESCRIPTION
In certain cases generators can begin running and throw an exception before its promise is retrieved and marked as yielded.
Current code rethrow the exception as soon as the generator throw if the promise is not marked yielded yet, but if its promise is eventually yieded later, we just want to fail the promise, allowing catching the exception at yield time.

To fix this, we defer checking yielded state and throwing exception at promise __destructor time, unmanaged failing promise will now throw at garbage collection of the promise.