### PR TITLE
Fixed AMP silent errors

### DIFF
--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -56,6 +56,8 @@ class EventLoop implements \M6Web\Tornado\EventLoop
                 }
             } catch (\Throwable $throwable) {
                 $deferred->reject($throwable);
+
+                return;
             }
 
             $deferred->resolve($generator->getReturn());

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -62,7 +62,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
         };
 
         $deferred = Internal\Deferred::forAsync();
-        new \Amp\Coroutine($wrapper($generator, $deferred));
+        \Amp\Promise\rethrow(new \Amp\Coroutine($wrapper($generator, $deferred)));
 
         return $deferred->getPromise();
     }
@@ -120,7 +120,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
         $promises = Internal\PromiseWrapper::toWatchedAmpPromiseArray(...$promises);
 
         foreach ($promises as $index => $promise) {
-            new \Amp\Coroutine($wrapPromise($promise));
+            \Amp\Promise\rethrow(new \Amp\Coroutine($wrapPromise($promise)));
         }
 
         return new Internal\PromiseWrapper($deferred->promise());


### PR DESCRIPTION
In Tornado, we prefer to **not** hide any errors. (I'll write a small paragraph in documentation about it in an other PR).
Then with AMP Adapter, all *internal* background AMP promise must use [`rethrow`](https://amphp.org/amp/promises/miscellaneous#rethrow) to ensure that no exception will be ignored.

Once this is fixed, a bug is revealed: our `async` function try to resolve a `deferred` twice, and we have a Php error when we try to call `getReturn` on a unfinished generator.

So here 2 commits, first one to *rethrow* all exceptions, and the last to fix a (previously) hidden error.