### PR TITLE
Add void return type when appropriated

### DIFF
--- a/src/Adapter/Amp/Internal/Deferred.php
+++ b/src/Adapter/Amp/Internal/Deferred.php
@@ -42,7 +42,7 @@ class Deferred implements \M6Web\Tornado\Deferred
     /**
      * {@inheritdoc}
      */
-    public function resolve($value)
+    public function resolve($value): void
     {
         $this->ampDeferred->resolve($value);
     }
@@ -50,7 +50,7 @@ class Deferred implements \M6Web\Tornado\Deferred
     /**
      * {@inheritdoc}
      */
-    public function reject(\Throwable $throwable)
+    public function reject(\Throwable $throwable): void
     {
         $this->ampDeferred->fail($throwable);
     }

--- a/src/Adapter/ReactPhp/Internal/Deferred.php
+++ b/src/Adapter/ReactPhp/Internal/Deferred.php
@@ -42,7 +42,7 @@ class Deferred implements \M6Web\Tornado\Deferred
     /**
      * {@inheritdoc}
      */
-    public function resolve($value)
+    public function resolve($value): void
     {
         $this->reactDeferred->resolve($value);
     }
@@ -50,7 +50,7 @@ class Deferred implements \M6Web\Tornado\Deferred
     /**
      * {@inheritdoc}
      */
-    public function reject(\Throwable $throwable)
+    public function reject(\Throwable $throwable): void
     {
         $this->reactDeferred->reject($throwable);
     }

--- a/src/Adapter/Tornado/EventLoop.php
+++ b/src/Adapter/Tornado/EventLoop.php
@@ -196,7 +196,10 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseFulfilled($value): Promise
     {
-        return Internal\PendingPromise::createHandled()->resolve($value);
+        $promise = Internal\PendingPromise::createHandled();
+        $promise->resolve($value);
+
+        return $promise;
     }
 
     /**
@@ -205,7 +208,10 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     public function promiseRejected(\Throwable $throwable): Promise
     {
         // Manually created promises are considered as handled.
-        return Internal\PendingPromise::createHandled()->reject($throwable);
+        $promise = Internal\PendingPromise::createHandled();
+        $promise->reject($throwable);
+
+        return $promise;
     }
 
     /**

--- a/src/Adapter/Tornado/Internal/PendingPromise.php
+++ b/src/Adapter/Tornado/Internal/PendingPromise.php
@@ -54,15 +54,15 @@ class PendingPromise implements Promise, Deferred
         return $promise;
     }
 
-    public function resolve($value): self
+    public function resolve($value): void
     {
         $this->settle();
         $this->value = $value;
 
-        return $this->triggerCallbacks();
+        $this->triggerCallbacks();
     }
 
-    public function reject(\Throwable $throwable): self
+    public function reject(\Throwable $throwable): void
     {
         $this->settle();
         $this->throwable = $throwable;
@@ -71,7 +71,7 @@ class PendingPromise implements Promise, Deferred
             $this->failingPromiseCollection->watchFailingPromise($this, $throwable);
         }
 
-        return $this->triggerCallbacks();
+        $this->triggerCallbacks();
     }
 
     public function getPromise(): Promise

--- a/src/Adapter/Tornado/SynchronousEventLoop.php
+++ b/src/Adapter/Tornado/SynchronousEventLoop.php
@@ -113,7 +113,10 @@ class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseFulfilled($value): Promise
     {
-        return Internal\PendingPromise::createHandled()->resolve($value);
+        $promise = Internal\PendingPromise::createHandled();
+        $promise->resolve($value);
+
+        return $promise;
     }
 
     /**
@@ -121,7 +124,10 @@ class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseRejected(\Throwable $throwable): Promise
     {
-        return Internal\PendingPromise::createHandled()->reject($throwable);
+        $promise = Internal\PendingPromise::createHandled();
+        $promise->reject($throwable);
+
+        return $promise;
     }
 
     /**
@@ -163,12 +169,12 @@ class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
                 return $this->promise;
             }
 
-            public function resolve($value)
+            public function resolve($value): void
             {
                 $this->promise = $this->eventLoop->promiseFulfilled($value);
             }
 
-            public function reject(\Throwable $throwable)
+            public function reject(\Throwable $throwable): void
             {
                 $this->promise = $this->eventLoop->promiseRejected($throwable);
             }

--- a/src/Deferred.php
+++ b/src/Deferred.php
@@ -15,10 +15,10 @@ interface Deferred
     /**
      * Resolves associated promise.
      */
-    public function resolve($value);
+    public function resolve($value): void;
 
     /**
      * Rejects associated promise.
      */
-    public function reject(\Throwable $throwable);
+    public function reject(\Throwable $throwable): void;
 }


### PR DESCRIPTION
Since Php 7.1, it's allowed to use `void` as a function return type.
See: https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.void-functions

It makes function easier to understand, since we can now see a difference between a function returning a mixed value (without return type) or returning nothing (`void`).