### PR TITLE
Adding Symfony HttpClient support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,19 @@
         "ext-curl": "^7.1",
         "react/event-loop": "^1.0",
         "react/promise": "^2.7",
-        "phpstan/phpstan": "^0.10.5"
+        "phpstan/phpstan": "^0.10.5",
+        "symfony/http-client": "^4.3",
+        "psr/http-factory": "^1.0",
+        "http-interop/http-factory-guzzle": "^1.0"
     },
     "suggest": {
-        "amphp/amp": "Needed to use Tornado\\Adapter\\Amp\\EventLoop",
-        "react/event-loop": "Needed to use Tornado\\Adapter\\ReactPhp\\EventLoop",
-        "react/promise": "Needed to use Tornado\\Adapter\\ReactPhp\\EventLoop",
-        "guzzlehttp/guzzle": "Needed to use Tornado\\Adapter\\Guzzle\\HttpClient"
+        "ext-curl": "Required to use Curl and HTTP2 features",
+        "amphp/amp": "Required to use Tornado\\Adapter\\Amp\\EventLoop",
+        "react/event-loop": "Required to use Tornado\\Adapter\\ReactPhp\\EventLoop",
+        "react/promise": "Required to use Tornado\\Adapter\\ReactPhp\\EventLoop",
+        "guzzlehttp/guzzle": "Required to use Tornado\\Adapter\\Guzzle\\HttpClient",
+        "symfony/http-client": "Required to use Tornado\\Adapter\\Symfony\\HttpClient",
+        "psr/http-factory": "Required to use Tornado\\Adapter\\Symfony\\HttpClient"
     },
     "config": {
         "bin-dir": "bin/"

--- a/examples/03-http-client.php
+++ b/examples/03-http-client.php
@@ -10,7 +10,7 @@ use M6Web\Tornado\HttpClient;
 function monitorRequest(EventLoop $eventLoop, HttpClient $httpClient, string $uri): \Generator
 {
     // Let's use Guzzle Psr7 implementation
-    $request = new \GuzzleHttp\Psr7\Request('GET', $uri);
+    $request = new \GuzzleHttp\Psr7\Request('GET', $uri, [], null, '2.0');
 
     $start = microtime(true);
     /** @var \Psr\Http\Message\ResponseInterface */
@@ -26,22 +26,28 @@ $eventLoop = new Adapter\Tornado\EventLoop();
 //$eventLoop = new Adapter\Amp\EventLoop();
 //$eventLoop = new Adapter\ReactPhp\EventLoop(new React\EventLoop\StreamSelectLoop());
 
-// Tornado provides only one HttpClient implementation, using Guzzle
-$httpClient = new Adapter\Guzzle\HttpClient($eventLoop, new Adapter\Guzzle\CurlMultiClientWrapper());
+// Choose your adapter
+$httpClient = new Adapter\Symfony\HttpClient(new \Symfony\Component\HttpClient\CurlHttpClient(), $eventLoop, new \Http\Factory\Guzzle\ResponseFactory(), new \Http\Factory\Guzzle\StreamFactory());
+//$httpClient = new Adapter\Guzzle\HttpClient($eventLoop, new Adapter\Guzzle\CurlMultiClientWrapper());
 
 // Let's call several endpoints… concurrently!
 echo "Let's start!\n";
 echo "Requests in progress…\n";
 $start = microtime(true);
-$results = $eventLoop->wait(
-    $eventLoop->promiseAll(
-        $eventLoop->async(monitorRequest($eventLoop, $httpClient, 'http://httpbin.org/status/404')),
-        $eventLoop->async(monitorRequest($eventLoop, $httpClient, 'http://www.google.com')),
-        $eventLoop->async(monitorRequest($eventLoop, $httpClient, 'http://www.example.com'))
-    )
-);
+$promises = [];
+// You can download up to 379 parts.
+// Check https://http2.akamai.com/demo for the full HTTP2 demonstration.
+for ($i = 0; $i < 10; $i++) {
+    $promises[] = $eventLoop->async(monitorRequest(
+            $eventLoop,
+            $httpClient,
+        "https://http2.akamai.com/demo/tile-$i.png"
+    ));
+}
+
+$results = $eventLoop->wait($eventLoop->promiseAll(...$promises));
 $duration = microtime(true) - $start;
 
-echo "Global duration: $duration\n";
 echo implode(PHP_EOL, $results).PHP_EOL;
+echo "Global duration: $duration\n";
 echo "Finished!\n";

--- a/src/Adapter/Symfony/HttpClient.php
+++ b/src/Adapter/Symfony/HttpClient.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace M6Web\Tornado\Adapter\Symfony;
+
+use M6Web\Tornado\Deferred;
+use M6Web\Tornado\EventLoop;
+use M6Web\Tornado\Promise;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Symfony\Contracts\HttpClient\ChunkInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface as SfHttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface as SfResponseInterface;
+
+class HttpClient implements \M6Web\Tornado\HttpClient
+{
+    /** @var SfHttpClientInterface */
+    private $symfonyClient;
+
+    /** @var EventLoop */
+    private $eventLoop;
+
+    /** @var SfResponseInterface[] */
+    private $jobs = [];
+
+    /** @var ResponseFactoryInterface */
+    private $responseFactory;
+
+    /** @var StreamFactoryInterface */
+    private $streamFactory;
+
+    /** @var int */
+    private $lastRequestId = 0;
+
+    public function __construct(SfHttpClientInterface $symfonyClient, EventLoop $eventLoop, ResponseFactoryInterface $responseFactory, StreamFactoryInterface $streamFactory)
+    {
+        $this->symfonyClient = $symfonyClient;
+        $this->eventLoop = $eventLoop;
+        $this->responseFactory = $responseFactory;
+        $this->streamFactory = $streamFactory;
+    }
+
+    public function sendRequest(RequestInterface $request): Promise
+    {
+        $body = $request->getBody();
+        if ($body->isSeekable()) {
+            $body->seek(0);
+        }
+
+        $requestId = $this->lastRequestId = ++$this->lastRequestId % PHP_INT_MAX;
+        try {
+            $this->jobs[$requestId] = $this->symfonyClient->request($request->getMethod(), (string) $request->getUri(), [
+                'headers' => $request->getHeaders(),
+                'body' => $body->getContents(),
+                'http_version' => $request->getProtocolVersion(),
+                'user_data' => [
+                    $deferred = $this->eventLoop->deferred(),
+                    $requestId,
+                ],
+            ]);
+        } catch (\Exception $exception) {
+            return $this->eventLoop->promiseRejected($exception);
+        }
+
+        // Register the internal event loop only for the first request
+        if (count($this->jobs) === 1) {
+            $this->eventLoop->async($this->symfonyEventLoop());
+        }
+
+        return $deferred->getPromise();
+    }
+
+    private function symfonyEventLoop(): \Generator
+    {
+        do {
+            yield $this->eventLoop->idle();
+
+            $currentJobs = $this->jobs;
+            $this->jobs = [];
+            /**
+             * @var SfResponseInterface
+             * @var ChunkInterface      $chunk
+             */
+            foreach ($this->symfonyClient->stream($currentJobs, 0) as $response => $chunk) {
+                /** @var Deferred $deferred */
+                [$deferred, $requestId] = $response->getInfo('user_data');
+
+                try {
+                    if ($chunk->isTimeout() || !$chunk->isLast()) {
+                        // To prevent the client to throw an exception
+                        // https://github.com/symfony/symfony/issues/32673#issuecomment-548327270
+                        $response->getStatusCode();
+                        $this->jobs[$requestId] = $response;
+                        continue;
+                    }
+
+                    // the full content of $response just completed
+                    // $response->getContent() is now a non-blocking call
+                    $deferred->resolve($this->toPsrResponse($response));
+
+                    // Stream loop may yield the same response several times,
+                    // then the response may already by in the list of responses to process.
+                    // To prevent to resolve it twice, remove it.
+                    unset($this->jobs[$requestId]);
+                } catch (\Throwable $exception) {
+                    $deferred->reject($exception);
+                }
+            }
+        } while ($this->jobs);
+    }
+
+    /**
+     * Inspired from https://github.com/symfony/http-client/blob/master/Psr18Client.php
+     *
+     * @throws \Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface
+     * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
+     */
+    private function toPsrResponse(SfResponseInterface $response): ResponseInterface
+    {
+        $psrResponse = $this->responseFactory->createResponse($response->getStatusCode());
+        foreach ($response->getHeaders(false) as $name => $values) {
+            foreach ($values as $value) {
+                $psrResponse = $psrResponse->withAddedHeader($name, $value);
+            }
+        }
+
+        $body = $this->streamFactory->createStream($response->getContent(false));
+
+        if ($body->isSeekable()) {
+            $body->seek(0);
+        }
+
+        return $psrResponse->withBody($body);
+    }
+}
+
+/**
+ * @internal
+ */
+class InternalSymfonyJob
+{
+    /** @var Deferred */
+    public $deferred;
+    /** @var SfResponseInterface */
+    public $response;
+
+    public function __construct(Deferred $deferred, SfResponseInterface $response)
+    {
+        $this->deferred = $deferred;
+        $this->response = $response;
+    }
+}

--- a/src/EventLoop.php
+++ b/src/EventLoop.php
@@ -30,8 +30,6 @@ interface EventLoop
      *
      * @param \Traversable|array $traversable Input elements
      * @param callable           $function    must return a generator from an input value, and an optional key
-     *
-     * @return Promise
      */
     public function promiseForeach($traversable, callable $function): Promise;
 
@@ -71,8 +69,6 @@ interface EventLoop
      * Returns a promise that will be resolved with the input stream when it becomes readable.
      *
      * @param resource $stream
-     *
-     * @return Promise
      */
     public function readable($stream): Promise;
 
@@ -80,8 +76,6 @@ interface EventLoop
      * Returns a promise that will be resolved with the input stream when it becomes writable.
      *
      * @param resource $stream
-     *
-     * @return Promise
      */
     public function writable($stream): Promise;
 }

--- a/tests/Adapter/Symfony/HttpClientTest.php
+++ b/tests/Adapter/Symfony/HttpClientTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace M6WebTest\Tornado\Adapter\Symfony;
+
+use M6Web\Tornado\EventLoop;
+use M6Web\Tornado\HttpClient;
+use Psr\Http\Message\ResponseInterface;
+
+class HttpClientTest extends \M6WebTest\Tornado\HttpClientTest
+{
+    protected function createHttpClient(EventLoop $eventLoop, array $responsesOrExceptions): HttpClient
+    {
+        $callback = function ($method, $url, $options) use (&$responsesOrExceptions) {
+            $response = array_shift($responsesOrExceptions);
+            if ($response instanceof \Exception) {
+                throw $response;
+            }
+            /* @var ResponseInterface $response */
+
+            return new \Symfony\Component\HttpClient\Response\MockResponse(
+                (string) $response->getBody(),
+                [
+                    'response_headers' => $response->getHeaders(),
+                    'redirect_count' => 0,
+                    'redirect_url' => null,
+                    'start_time' => microtime(true),
+                    'http_method' => $method,
+                    'http_code' => $response->getStatusCode(),
+                    'error' => null,
+                    'user_data' => $options['user_data'],
+                    'url' => $url,
+                ]
+            );
+        };
+
+        return new \M6Web\Tornado\Adapter\Symfony\HttpClient(
+            new \Symfony\Component\HttpClient\MockHttpClient($callback),
+            $eventLoop,
+            new \Http\Factory\Guzzle\ResponseFactory(),
+            new \Http\Factory\Guzzle\StreamFactory()
+        );
+    }
+}

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -11,10 +11,7 @@ use PHPUnit\Framework\TestCase;
 abstract class HttpClientTest extends TestCase
 {
     /**
-     * @param EventLoop $eventLoop
-     * @param array     $responsesOrExceptions Psr7\Response to return, or \Exception to throw
-     *
-     * @return HttpClient
+     * @param array $responsesOrExceptions Psr7\Response to return, or \Exception to throw
      */
     abstract protected function createHttpClient(EventLoop $eventLoop, array $responsesOrExceptions): HttpClient;
 
@@ -33,14 +30,14 @@ abstract class HttpClientTest extends TestCase
     {
         $httpClient = $this->createHttpClient(
             $eventLoop,
-            [new Response(200, [], 'Example Domain')]
+            [new Response(200, [], 'This is a test')]
         );
         $request = new Request('GET', 'http://www.example.com');
 
         $response = $eventLoop->wait($httpClient->sendRequest($request));
 
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertContains('Example Domain', (string) $response->getBody());
+        $this->assertContains('This is a test', (string) $response->getBody());
     }
 
     /**
@@ -58,6 +55,24 @@ abstract class HttpClientTest extends TestCase
         $response = $eventLoop->wait($httpClient->sendRequest($request));
 
         $this->assertSame(404, $response->getStatusCode());
+    }
+
+    /**
+     * @dataProvider eventLoopProvider
+     */
+    public function testGetServerErrorUrl(EventLoop $eventLoop)
+    {
+        $httpClient = $this->createHttpClient(
+            $eventLoop,
+            [new Response(500, [], 'Error')]
+        );
+
+        $request = new Request('GET', 'http://www.example.com/500');
+
+        $response = $eventLoop->wait($httpClient->sendRequest($request));
+
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertContains('Error', (string) $response->getBody());
     }
 
     /**


### PR DESCRIPTION
Symfony released a new [HttpClient](https://github.com/symfony/http-client) component, with support of asynchronous requests and Http2 support. This PR add an adapter for this new HttpClient.

The **big** change is the  support of HTTP2, the `examples/03-http-client.php` has been adapted to show the performances gain: up to **4x times faster** in Http2 🎉 . Of course, this example is an ideal case, where all requests are made on the same server supporting Http2, but it's promising.

**Note**: Symfony client does not support PSR-7 interfaces natively, then you need to provide some factories (PSR-17)to instantiate PSR-7 responses, https://github.com/Nyholm/http-factory is suggested