### PR TITLE
(test) Update amp test because of a library change

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "M6WebTest\\Tornado\\": "tests/"
+            "M6WebTest\\Tornado\\": "tests/",
+            "M6WebExamples\\Tornado\\": "examples/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         {
             "name": "M6Web",
             "email": "opensource@m6web.fr",
-            "homepage": "http://tech.m6web.fr/"
+            "homepage": "https://tech.bedrockstreaming.com"
         }
     ],
     "autoload": {

--- a/examples/00-README-samples.php
+++ b/examples/00-README-samples.php
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+namespace M6WebExamples\Tornado;
+
 require __DIR__.'/../vendor/autoload.php';
 
 use GuzzleHttp\Psr7;

--- a/examples/01-async-countdown.php
+++ b/examples/01-async-countdown.php
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+namespace M6WebExamples\Tornado;
+
 require __DIR__.'/../vendor/autoload.php';
 
 use M6Web\Tornado\Adapter;

--- a/examples/02-failures.php
+++ b/examples/02-failures.php
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+namespace M6WebExamples\Tornado;
+
 require __DIR__.'/../vendor/autoload.php';
 
 use M6Web\Tornado\Adapter;

--- a/examples/03-http-client.php
+++ b/examples/03-http-client.php
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+namespace M6WebExamples\Tornado;
+
 require __DIR__.'/../vendor/autoload.php';
 
 use M6Web\Tornado\Adapter;

--- a/examples/04-foreach.php
+++ b/examples/04-foreach.php
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+namespace M6WebExamples\Tornado;
+
 require __DIR__.'/../vendor/autoload.php';
 
 use M6Web\Tornado\Adapter;

--- a/examples/Tests/ExamplesTest.php
+++ b/examples/Tests/ExamplesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace M6WebExamplesTest\Tornado;
+namespace M6WebExamples\Tornado\Tests;
 
 use PHPUnit\Framework\TestCase;
 

--- a/src/Adapter/Amp/Internal/Deferred.php
+++ b/src/Adapter/Amp/Internal/Deferred.php
@@ -10,14 +10,10 @@ use M6Web\Tornado\Promise;
  */
 class Deferred implements \M6Web\Tornado\Deferred
 {
-    /**
-     * @var \Amp\Deferred
-     */
+    /** @var \Amp\Deferred */
     private $ampDeferred;
 
-    /**
-     * @var PromiseWrapper
-     */
+    /** @var PromiseWrapper */
     private $promise;
 
     public function __construct(\Amp\Deferred $ampDeferred, PromiseWrapper $promise)

--- a/src/Adapter/Amp/Internal/PromiseWrapper.php
+++ b/src/Adapter/Amp/Internal/PromiseWrapper.php
@@ -11,9 +11,7 @@ use M6Web\Tornado\Promise;
  */
 class PromiseWrapper implements Promise
 {
-    /**
-     * @var \Amp\Promise
-     */
+    /** @var \Amp\Promise */
     private $ampPromise;
 
     /** @var bool */

--- a/src/Adapter/Guzzle/CurlMultiClientWrapper.php
+++ b/src/Adapter/Guzzle/CurlMultiClientWrapper.php
@@ -4,14 +4,10 @@ namespace M6Web\Tornado\Adapter\Guzzle;
 
 final class CurlMultiClientWrapper implements GuzzleClientWrapper
 {
-    /**
-     * @var \GuzzleHttp\Handler\CurlMultiHandler
-     */
+    /** @var \GuzzleHttp\Handler\CurlMultiHandler */
     private $curlMultiHandler;
 
-    /**
-     * @var \GuzzleHttp\Client
-     */
+    /** @var \GuzzleHttp\Client */
     private $guzzleClient;
 
     /**

--- a/src/Adapter/Guzzle/HttpClient.php
+++ b/src/Adapter/Guzzle/HttpClient.php
@@ -10,14 +10,10 @@ use Psr\Http\Message\ResponseInterface;
 
 class HttpClient implements \M6Web\Tornado\HttpClient
 {
-    /**
-     * @var EventLoop
-     */
+    /** @var EventLoop */
     private $eventLoop;
 
-    /**
-     * @var GuzzleClientWrapper
-     */
+    /** @var GuzzleClientWrapper */
     private $clientWrapper;
 
     private $nbConcurrentRequests = 0;

--- a/src/Adapter/ReactPhp/EventLoop.php
+++ b/src/Adapter/ReactPhp/EventLoop.php
@@ -196,7 +196,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     {
         $deferred = $this->deferred();
         $this->reactEventLoop->addTimer(
-            $milliseconds / 1000 /* milliseconds per second */,
+            $milliseconds / 1000 /* milliseconds per second */ ,
             function () use ($deferred) {
                 $deferred->resolve(null);
             }

--- a/src/Adapter/ReactPhp/Internal/Deferred.php
+++ b/src/Adapter/ReactPhp/Internal/Deferred.php
@@ -10,14 +10,10 @@ use M6Web\Tornado\Promise;
  */
 class Deferred implements \M6Web\Tornado\Deferred
 {
-    /**
-     * @var \React\Promise\Deferred
-     */
+    /** @var \React\Promise\Deferred */
     private $reactDeferred;
 
-    /**
-     * @var PromiseWrapper
-     */
+    /** @var PromiseWrapper */
     private $promise;
 
     public function __construct(\React\Promise\Deferred $reactDeferred, PromiseWrapper $promiseWrapper)

--- a/src/Adapter/ReactPhp/Internal/PromiseWrapper.php
+++ b/src/Adapter/ReactPhp/Internal/PromiseWrapper.php
@@ -11,9 +11,7 @@ use M6Web\Tornado\Promise;
  */
 class PromiseWrapper implements Promise
 {
-    /**
-     * @var \React\Promise\PromiseInterface
-     */
+    /** @var \React\Promise\PromiseInterface */
     private $reactPromise;
 
     /** @var bool */

--- a/src/Adapter/Tornado/Internal/StreamEventLoop.php
+++ b/src/Adapter/Tornado/Internal/StreamEventLoop.php
@@ -9,17 +9,11 @@ use M6Web\Tornado\EventLoop;
  */
 class StreamEventLoop
 {
-    /**
-     * @var resource[]
-     */
+    /** @var resource[] */
     private $readStreams = [];
-    /**
-     * @var resource[]
-     */
+    /** @var resource[] */
     private $writeStreams = [];
-    /**
-     * @var PendingPromise[]
-     */
+    /** @var PendingPromise[] */
     private $pendingPromises = [];
 
     public function readable(EventLoop $eventLoop, $stream): PendingPromise

--- a/src/Adapter/Tornado/SynchronousEventLoop.php
+++ b/src/Adapter/Tornado/SynchronousEventLoop.php
@@ -7,9 +7,7 @@ use M6Web\Tornado\Promise;
 
 class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
 {
-    /**
-     * @var \Throwable[]
-     */
+    /** @var \Throwable[] */
     private $asyncThrowables = [];
 
     /**

--- a/tests/Adapter/Amp/EventLoopTest.php
+++ b/tests/Adapter/Amp/EventLoopTest.php
@@ -17,4 +17,20 @@ class EventLoopTest extends \M6WebTest\Tornado\EventLoopTest
         // Because Amp resolve promises in a slightly different order.
         parent::testStreamShouldReadFromWritable('W0R0W12345R12R34W6R56R');
     }
+
+    public function testStreamShouldNotBeWritableIfClosed()
+    {
+        assert_options(ASSERT_EXCEPTION, 1);
+        $this->expectException(\Throwable::class);
+
+        parent::testStreamShouldNotBeWritableIfClosed();
+    }
+
+    public function testStreamShouldNotBeReadableIfClosed()
+    {
+        assert_options(ASSERT_EXCEPTION, 1);
+        $this->expectException(\Throwable::class);
+
+        parent::testStreamShouldNotBeReadableIfClosed();
+    }
 }

--- a/tests/Adapter/Guzzle/GuzzleMockWrapper.php
+++ b/tests/Adapter/Guzzle/GuzzleMockWrapper.php
@@ -7,19 +7,13 @@ use M6Web\Tornado\Adapter\Guzzle\GuzzleClientWrapper;
 
 final class GuzzleMockWrapper implements GuzzleClientWrapper
 {
-    /**
-     * @var \GuzzleHttp\Client
-     */
+    /** @var \GuzzleHttp\Client */
     private $guzzleClient;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private $transactions = [];
 
-    /**
-     * @var int
-     */
+    /** @var int */
     public $ticks;
 
     public function __construct(array $queue)


### PR DESCRIPTION
## Why
Amp changed its library, now using asserts.
When a stream is closed, it now either throws an exception, or an assert error depending on the php configuration used.
Before that, the promise would have gone silent. This is the expected behaviour and Tornado should respect it.

## How
Update the test to reflect this change.

## Note
I guess it is up to the people using stream to wrap their promises inside failsafe promises depending on how they want to handle them.