### PR TITLE
Fixed CI: examples are not tested

### DIFF
--- a/examples/00-README-samples.php
+++ b/examples/00-README-samples.php
@@ -100,7 +100,7 @@ function waitException(Tornado\EventLoop $eventLoop)
 $eventLoop = new Tornado\Adapter\Tornado\EventLoop();
 //$eventLoop = new Tornado\Adapter\Tornado\SynchronousEventLoop();
 //$eventLoop = new Tornado\Adapter\Amp\EventLoop();
-//$eventLoop = new Tornado\Adapter\ReactPhp\EventLoop(new React\EventLoop\StreamSelectLoop());
+//$eventLoop = new Tornado\Adapter\ReactPhp\EventLoop(new \React\EventLoop\StreamSelectLoop());
 
 // Tornado provides only one HttpClient implementation, using Guzzle
 $httpClient = new Tornado\Adapter\Guzzle\HttpClient($eventLoop, new Tornado\Adapter\Guzzle\CurlMultiClientWrapper());

--- a/examples/01-async-countdown.php
+++ b/examples/01-async-countdown.php
@@ -26,7 +26,7 @@ function asynchronousCountdown(EventLoop $eventLoop, string $name, int $count): 
 $eventLoop = new Adapter\Tornado\EventLoop();
 //$eventLoop = new Adapter\Tornado\SynchronousEventLoop();
 //$eventLoop = new Adapter\Amp\EventLoop();
-//$eventLoop = new Adapter\ReactPhp\EventLoop(new React\EventLoop\StreamSelectLoop());
+//$eventLoop = new Adapter\ReactPhp\EventLoop(new \React\EventLoop\StreamSelectLoop());
 
 echo "Let's start!\n";
 

--- a/examples/02-failures.php
+++ b/examples/02-failures.php
@@ -18,7 +18,7 @@ function throwingGenerator(): \Generator
 $eventLoop = new Adapter\Tornado\EventLoop();
 //$eventLoop = new Adapter\Tornado\SynchronousEventLoop();
 //$eventLoop = new Adapter\Amp\EventLoop();
-//$eventLoop = new Adapter\ReactPhp\EventLoop(new React\EventLoop\StreamSelectLoop());
+//$eventLoop = new Adapter\ReactPhp\EventLoop(new \React\EventLoop\StreamSelectLoop());
 
 echo "Let's start!\n";
 

--- a/examples/03-http-client.php
+++ b/examples/03-http-client.php
@@ -26,7 +26,7 @@ function monitorRequest(EventLoop $eventLoop, HttpClient $httpClient, string $ur
 $eventLoop = new Adapter\Tornado\EventLoop();
 //$eventLoop = new Adapter\Tornado\SynchronousEventLoop();
 //$eventLoop = new Adapter\Amp\EventLoop();
-//$eventLoop = new Adapter\ReactPhp\EventLoop(new React\EventLoop\StreamSelectLoop());
+//$eventLoop = new Adapter\ReactPhp\EventLoop(new \React\EventLoop\StreamSelectLoop());
 
 // Choose your adapter
 $httpClient = new Adapter\Symfony\HttpClient(new \Symfony\Component\HttpClient\CurlHttpClient(), $eventLoop, new \Http\Factory\Guzzle\ResponseFactory(), new \Http\Factory\Guzzle\StreamFactory());

--- a/examples/04-foreach.php
+++ b/examples/04-foreach.php
@@ -69,7 +69,7 @@ function compareMethods(EventLoop $eventLoop)
 $eventLoop = new Adapter\Tornado\EventLoop();
 //$eventLoop = new Adapter\Tornado\SynchronousEventLoop();
 //$eventLoop = new Adapter\Amp\EventLoop();
-//$eventLoop = new Adapter\ReactPhp\EventLoop(new React\EventLoop\StreamSelectLoop());
+//$eventLoop = new Adapter\ReactPhp\EventLoop(new \React\EventLoop\StreamSelectLoop());
 
 echo "Let's start!\n";
 // Run the event loop until our goal promise is reached.

--- a/examples/tests/ExamplesTest.php
+++ b/examples/tests/ExamplesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace M6WebExamples\Tornado\Tests;
+namespace M6WebExamplesTests\Tornado;
 
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
In PR #43 , examples are not run, 0 tests are found…
I'm trying locally, and I found some typo, so these examples never ran on CI… 😫 

It's due to a case mistake in the folder name, I created a `Tests` folder to match a namespace, but the test suite was configured to scan the `tests` folder (by convention 🤷‍♂️ ). I detected nothing locally because OsX filesystem is case-insensitive 🤦‍♂️ 

The good way to go:
* Use a `tests` folder
* Modify the namespace, with the same convention than in unit tests, _i.e._ a _vendor_ containing `Tests`