### PR TITLE
feat: bump amp to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
         strategy:
             matrix:
-                php: [ '8.1', '8.2', '8.3' ]
+                php: [ '8.1', '8.2', '8.3', '8.4' ]
 
         steps:
             - name: 'Init repository'

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,7 +9,19 @@ $finder->in(
     ]
 );
 
-$config = new M6Web\CS\Config\BedrockStreaming();
+$baseConfig = new M6Web\CS\Config\BedrockStreaming();
+
+$config = new PhpCsFixer\Config('Bedrock Streaming');
 $config->setFinder($finder);
+
+$override_rules = array_merge(
+    $baseConfig->getRules(),
+    [
+        // Adding strict_types should be part of another PR
+        'declare_strict_types' => false,
+    ]
+);
+
+$config->setRules($override_rules);
 
 return $config;

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",
-        "amphp/amp": "^2.0",
+        "amphp/amp": "^3.0",
         "guzzlehttp/guzzle": "^7.4",
         "m6web/php-cs-fixer-config": "^2.0",
         "ext-curl": "^8.1",
         "react/event-loop": "^1.0",
         "react/promise": "^2.7",
-        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan": "^1.10",
         "symfony/http-client": "^6.4",
         "psr/http-factory": "^1.0",
         "http-interop/http-factory-guzzle": "^1.0"

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -18,7 +18,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     public function wait(Promise $promise)
     {
         try {
-            $result = \Amp\Future\await([Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises)->getAmpFuture()]);
+            $result = \Amp\Future\await([Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises)->ampFuture]);
             $this->unhandledFailingPromises->throwIfWatchedFailingPromiseExists();
 
             return $result[0] ?? null;
@@ -54,7 +54,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
                     $blockingPromise = Internal\PromiseWrapper::toHandledPromise(
                         $blockingPromise,
                         $this->unhandledFailingPromises
-                    )->getAmpFuture();
+                    )->ampFuture;
 
                     // Forwards promise value/exception to underlying generator
                     $blockingPromiseValue = null;
@@ -91,7 +91,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     public function promiseAll(Promise ...$promises): Promise
     {
         $futures = array_map(
-            fn (Promise $promise) => Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises)->getAmpFuture(),
+            fn (Promise $promise) => Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises)->ampFuture,
             $promises
         );
 
@@ -154,7 +154,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
             fn (Promise $promise) => Internal\PromiseWrapper::toHandledPromise(
                 $promise,
                 $this->unhandledFailingPromises
-            )->getAmpFuture(),
+            )->ampFuture,
             $promises
         );
 

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace M6Web\Tornado\Adapter\Amp;
 
 use Amp\Future;
+use Amp\Internal\FutureIterator;
 use M6Web\Tornado\Adapter\Common;
 use M6Web\Tornado\Deferred;
 use M6Web\Tornado\Promise;
@@ -89,17 +90,23 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseAll(Promise ...$promises): Promise
     {
-        $generator = function () use ($promises): \Generator {
-            $result = [];
+        $futures = array_map(
+            fn(Promise $promise) => Internal\PromiseWrapper::toHandledPromise($promise,$this->unhandledFailingPromises)->getAmpFuture(),
+            $promises
+        );
 
-            foreach ($promises as $promise) {
-                $result[] = yield Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises);
+        $future = \Amp\async(function() use ($futures) {
+            [$errors, $values] = \Amp\Future\awaitAll($futures);
+
+            ksort($errors);
+            ksort($values);
+            if(count($errors) > 0) {
+                throw reset($errors);
             }
 
-            return $result;
-        };
-
-        return $this->async($generator());
+            return $values;
+        });
+        return Internal\PromiseWrapper::createUnhandled($future,$this->unhandledFailingPromises);
     }
 
     /**

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace M6Web\Tornado\Adapter\Amp;
 
+use Amp\DeferredFuture;
 use Amp\Future;
-use Amp\Internal\FutureIterator;
 use M6Web\Tornado\Adapter\Common;
 use M6Web\Tornado\Deferred;
 use M6Web\Tornado\Promise;
@@ -44,7 +44,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function async(\Generator $generator): Promise
     {
-        $wrapper = function (\Generator $generator, \Amp\DeferredFuture $deferred) {
+        $wrapper = function (\Generator $generator, DeferredFuture $deferred) {
             try {
                 while ($generator->valid()) {
                     $blockingPromise = $generator->current();
@@ -79,8 +79,8 @@ class EventLoop implements \M6Web\Tornado\EventLoop
             $deferred->complete($generator->getReturn());
         };
 
-        $deferred = new \Amp\DeferredFuture();
-        \Amp\async(fn() => $wrapper($generator, $deferred));
+        $deferred = new DeferredFuture();
+        \Amp\async(fn () => $wrapper($generator, $deferred));
 
         return Internal\PromiseWrapper::createUnhandled($deferred->getFuture(), $this->unhandledFailingPromises);
     }
@@ -131,10 +131,10 @@ class EventLoop implements \M6Web\Tornado\EventLoop
             return $this->promiseFulfilled(null);
         }
 
-        $deferred = new \Amp\DeferredFuture();
+        $deferred = new DeferredFuture();
         $isFirstPromise = true;
 
-        $wrapPromise = function (\Amp\Future $future) use ($deferred, &$isFirstPromise) {
+        $wrapPromise = function (Future $future) use ($deferred, &$isFirstPromise) {
             try {
                 $result = $future->await();
                 if ($isFirstPromise) {
@@ -158,7 +158,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
         );
 
         foreach ($futures as $index => $future) {
-            \Amp\async(fn() => $wrapPromise($future));
+            \Amp\async(fn () => $wrapPromise($future));
         }
 
         return Internal\PromiseWrapper::createUnhandled($deferred->getFuture(), $this->unhandledFailingPromises);
@@ -185,7 +185,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function idle(): Promise
     {
-        $deferred = new \Amp\DeferredFuture();
+        $deferred = new DeferredFuture();
 
         \Revolt\EventLoop::defer(function () use ($deferred): void {
             $deferred->complete();
@@ -199,9 +199,9 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function delay(int $milliseconds): Promise
     {
-        $deferred = new \Amp\DeferredFuture();
+        $deferred = new DeferredFuture();
 
-        \Revolt\EventLoop::delay($milliseconds/1000, function () use ($deferred): void {
+        \Revolt\EventLoop::delay($milliseconds / 1000, function () use ($deferred): void {
             $deferred->complete();
         });
 
@@ -214,7 +214,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     public function deferred(): Deferred
     {
         return new Internal\Deferred(
-            $deferred = new \Amp\DeferredFuture(),
+            $deferred = new DeferredFuture(),
             Internal\PromiseWrapper::createHandled($deferred->getFuture())
         );
     }
@@ -224,7 +224,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function readable($stream): Promise
     {
-        $deferred = new \Amp\DeferredFuture();
+        $deferred = new DeferredFuture();
 
         \Revolt\EventLoop::onReadable(
             $stream,
@@ -242,7 +242,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function writable($stream): Promise
     {
-        $deferred = new \Amp\DeferredFuture();
+        $deferred = new DeferredFuture();
 
         \Revolt\EventLoop::onWritable(
             $stream,

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -104,13 +104,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
         );
 
         $future = \Amp\async(function () use (&$orderedResults, $futures): array {
-            [$errors, $values] = \Amp\Future\awaitAll($futures);
-
-            ksort($errors);
-
-            if (count($errors) > 0) {
-                throw reset($errors);
-            }
+            $values = \Amp\Future\await($futures);
 
             foreach ($values as $index => $value) {
                 $orderedResults[$index] = $value;

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -91,22 +91,23 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     public function promiseAll(Promise ...$promises): Promise
     {
         $futures = array_map(
-            fn(Promise $promise) => Internal\PromiseWrapper::toHandledPromise($promise,$this->unhandledFailingPromises)->getAmpFuture(),
+            fn (Promise $promise) => Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises)->getAmpFuture(),
             $promises
         );
 
-        $future = \Amp\async(function() use ($futures) {
+        $future = \Amp\async(function () use ($futures) {
             [$errors, $values] = \Amp\Future\awaitAll($futures);
 
             ksort($errors);
             ksort($values);
-            if(count($errors) > 0) {
+            if (count($errors) > 0) {
                 throw reset($errors);
             }
 
             return $values;
         });
-        return Internal\PromiseWrapper::createUnhandled($future,$this->unhandledFailingPromises);
+
+        return Internal\PromiseWrapper::createUnhandled($future, $this->unhandledFailingPromises);
     }
 
     /**

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -93,11 +93,11 @@ class EventLoop implements \M6Web\Tornado\EventLoop
             $result = [];
 
             foreach ($promises as $promise) {
-              $result[] = yield Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises);
+                $result[] = yield Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises);
             }
 
             return $result;
-          };
+        };
 
         return $this->async($generator());
     }

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -97,21 +97,26 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseAll(Promise ...$promises): Promise
     {
+        $orderedResults = \array_fill_keys(\array_keys($promises), null);
         $futures = array_map(
-            fn (Promise $promise) => Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises)->ampFuture,
+            fn (Promise $promise): Future => Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises)->ampFuture,
             $promises
         );
 
-        $future = \Amp\async(function () use ($futures) {
+        $future = \Amp\async(function () use (&$orderedResults, $futures): array {
             [$errors, $values] = \Amp\Future\awaitAll($futures);
 
             ksort($errors);
-            ksort($values);
+
             if (count($errors) > 0) {
                 throw reset($errors);
             }
 
-            return $values;
+            foreach ($values as $index => $value) {
+                $orderedResults[$index] = $value;
+            }
+
+            return $orderedResults;
         });
 
         return Internal\PromiseWrapper::createUnhandled($future, $this->unhandledFailingPromises);

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace M6Web\Tornado\Adapter\Amp;
 
+use Amp\Future;
 use M6Web\Tornado\Adapter\Common;
 use M6Web\Tornado\Deferred;
 use M6Web\Tornado\Promise;
@@ -16,25 +17,24 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     public function wait(Promise $promise)
     {
         try {
-            $result = \Amp\Promise\wait(
-                Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises)->getAmpPromise()
-            );
+            $result = \Amp\Future\await([Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises)->getAmpFuture()]);
             $this->unhandledFailingPromises->throwIfWatchedFailingPromiseExists();
 
-            return $result;
+            return $result[0] ?? null;
         } catch (\Error $error) {
             // Modify exceptions sent by Amp itself
             if ($error->getCode() !== 0) {
                 throw $error;
             }
-            switch ($error->getMessage()) {
-                case 'Loop stopped without resolving the promise':
-                    throw new \Error('Impossible to resolve the promise, no more task to execute.', 0, $error);
-                case 'Loop exceptionally stopped without resolving the promise':
-                    throw $error->getPrevious() ?? $error;
-                default:
-                    throw $error;
+
+            if (str_starts_with($error->getMessage(), 'Event loop terminated without resuming the current suspension')) {
+                throw new \Error('Impossible to resolve the promise, no more task to execute.', 0, $error);
             }
+
+            throw match ($error->getMessage()) {
+                'Loop exceptionally stopped without resolving the promise' => $error->getPrevious() ?? $error,
+                default => $error,
+            };
         }
     }
 
@@ -43,7 +43,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function async(\Generator $generator): Promise
     {
-        $wrapper = function (\Generator $generator, \Amp\Deferred $deferred): \Generator {
+        $wrapper = function (\Generator $generator, \Amp\DeferredFuture $deferred) {
             try {
                 while ($generator->valid()) {
                     $blockingPromise = $generator->current();
@@ -53,13 +53,13 @@ class EventLoop implements \M6Web\Tornado\EventLoop
                     $blockingPromise = Internal\PromiseWrapper::toHandledPromise(
                         $blockingPromise,
                         $this->unhandledFailingPromises
-                    )->getAmpPromise();
+                    )->getAmpFuture();
 
                     // Forwards promise value/exception to underlying generator
                     $blockingPromiseValue = null;
                     $blockingPromiseException = null;
                     try {
-                        $blockingPromiseValue = yield $blockingPromise;
+                        $blockingPromiseValue = $blockingPromise->await();
                     } catch (\Throwable $throwable) {
                         $blockingPromiseException = $throwable;
                     }
@@ -70,18 +70,18 @@ class EventLoop implements \M6Web\Tornado\EventLoop
                     }
                 }
             } catch (\Throwable $throwable) {
-                $deferred->fail($throwable);
+                $deferred->error($throwable);
 
                 return;
             }
 
-            $deferred->resolve($generator->getReturn());
+            $deferred->complete($generator->getReturn());
         };
 
-        $deferred = new \Amp\Deferred();
-        \Amp\Promise\rethrow(new \Amp\Coroutine($wrapper($generator, $deferred)));
+        $deferred = new \Amp\DeferredFuture();
+        \Amp\async(fn() => $wrapper($generator, $deferred));
 
-        return Internal\PromiseWrapper::createUnhandled($deferred->promise(), $this->unhandledFailingPromises);
+        return Internal\PromiseWrapper::createUnhandled($deferred->getFuture(), $this->unhandledFailingPromises);
     }
 
     /**
@@ -89,18 +89,17 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseAll(Promise ...$promises): Promise
     {
-        return Internal\PromiseWrapper::createUnhandled(
-            \Amp\Promise\all(
-                array_map(
-                    fn (Promise $promise) => Internal\PromiseWrapper::toHandledPromise(
-                        $promise,
-                        $this->unhandledFailingPromises
-                    )->getAmpPromise(),
-                    $promises
-                )
-            ),
-            $this->unhandledFailingPromises
-        );
+        $generator = function () use ($promises): \Generator {
+            $result = [];
+
+            foreach ($promises as $promise) {
+              $result[] = yield Internal\PromiseWrapper::toHandledPromise($promise, $this->unhandledFailingPromises);
+            }
+
+            return $result;
+          };
+
+        return $this->async($generator());
     }
 
     /**
@@ -125,37 +124,37 @@ class EventLoop implements \M6Web\Tornado\EventLoop
             return $this->promiseFulfilled(null);
         }
 
-        $deferred = new \Amp\Deferred();
+        $deferred = new \Amp\DeferredFuture();
         $isFirstPromise = true;
 
-        $wrapPromise = function (\Amp\Promise $promise) use ($deferred, &$isFirstPromise): \Generator {
+        $wrapPromise = function (\Amp\Future $future) use ($deferred, &$isFirstPromise) {
             try {
-                $result = yield $promise;
+                $result = $future->await();
                 if ($isFirstPromise) {
                     $isFirstPromise = false;
-                    $deferred->resolve($result);
+                    $deferred->complete($result);
                 }
             } catch (\Throwable $throwable) {
                 if ($isFirstPromise) {
                     $isFirstPromise = false;
-                    $deferred->fail($throwable);
+                    $deferred->error($throwable);
                 }
             }
         };
 
-        $promises = array_map(
+        $futures = array_map(
             fn (Promise $promise) => Internal\PromiseWrapper::toHandledPromise(
                 $promise,
                 $this->unhandledFailingPromises
-            )->getAmpPromise(),
+            )->getAmpFuture(),
             $promises
         );
 
-        foreach ($promises as $index => $promise) {
-            \Amp\Promise\rethrow(new \Amp\Coroutine($wrapPromise($promise)));
+        foreach ($futures as $index => $future) {
+            \Amp\async(fn() => $wrapPromise($future));
         }
 
-        return Internal\PromiseWrapper::createUnhandled($deferred->promise(), $this->unhandledFailingPromises);
+        return Internal\PromiseWrapper::createUnhandled($deferred->getFuture(), $this->unhandledFailingPromises);
     }
 
     /**
@@ -163,7 +162,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseFulfilled($value): Promise
     {
-        return Internal\PromiseWrapper::createHandled(new \Amp\Success($value));
+        return Internal\PromiseWrapper::createHandled(Future::complete($value));
     }
 
     /**
@@ -171,8 +170,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function promiseRejected(\Throwable $throwable): Promise
     {
-        // Manually created promises are considered as handled.
-        return Internal\PromiseWrapper::createHandled(new \Amp\Failure($throwable));
+        return Internal\PromiseWrapper::createHandled(Future::error($throwable));
     }
 
     /**
@@ -180,13 +178,13 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function idle(): Promise
     {
-        $deferred = new \Amp\Deferred();
+        $deferred = new \Amp\DeferredFuture();
 
-        \Amp\Loop::defer(function () use ($deferred): void {
-            $deferred->resolve();
+        \Revolt\EventLoop::defer(function () use ($deferred): void {
+            $deferred->complete();
         });
 
-        return Internal\PromiseWrapper::createUnhandled($deferred->promise(), $this->unhandledFailingPromises);
+        return Internal\PromiseWrapper::createUnhandled($deferred->getFuture(), $this->unhandledFailingPromises);
     }
 
     /**
@@ -194,13 +192,13 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function delay(int $milliseconds): Promise
     {
-        $deferred = new \Amp\Deferred();
+        $deferred = new \Amp\DeferredFuture();
 
-        \Amp\Loop::delay($milliseconds, function () use ($deferred): void {
-            $deferred->resolve();
+        \Revolt\EventLoop::delay($milliseconds/1000, function () use ($deferred): void {
+            $deferred->complete();
         });
 
-        return Internal\PromiseWrapper::createUnhandled($deferred->promise(), $this->unhandledFailingPromises);
+        return Internal\PromiseWrapper::createUnhandled($deferred->getFuture(), $this->unhandledFailingPromises);
     }
 
     /**
@@ -209,9 +207,8 @@ class EventLoop implements \M6Web\Tornado\EventLoop
     public function deferred(): Deferred
     {
         return new Internal\Deferred(
-            $deferred = new \Amp\Deferred(),
-            // Manually created promises are considered as handled.
-            Internal\PromiseWrapper::createHandled($deferred->promise())
+            $deferred = new \Amp\DeferredFuture(),
+            Internal\PromiseWrapper::createHandled($deferred->getFuture())
         );
     }
 
@@ -220,17 +217,17 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function readable($stream): Promise
     {
-        $deferred = new \Amp\Deferred();
+        $deferred = new \Amp\DeferredFuture();
 
-        \Amp\Loop::onReadable(
+        \Revolt\EventLoop::onReadable(
             $stream,
             function ($watcherId, $stream) use ($deferred): void {
-                \Amp\Loop::cancel($watcherId);
-                $deferred->resolve($stream);
+                \Revolt\EventLoop::cancel($watcherId);
+                $deferred->complete($stream);
             }
         );
 
-        return Internal\PromiseWrapper::createUnhandled($deferred->promise(), $this->unhandledFailingPromises);
+        return Internal\PromiseWrapper::createUnhandled($deferred->getFuture(), $this->unhandledFailingPromises);
     }
 
     /**
@@ -238,17 +235,17 @@ class EventLoop implements \M6Web\Tornado\EventLoop
      */
     public function writable($stream): Promise
     {
-        $deferred = new \Amp\Deferred();
+        $deferred = new \Amp\DeferredFuture();
 
-        \Amp\Loop::onWritable(
+        \Revolt\EventLoop::onWritable(
             $stream,
             function ($watcherId, $stream) use ($deferred): void {
-                \Amp\Loop::cancel($watcherId);
-                $deferred->resolve($stream);
+                \Revolt\EventLoop::cancel($watcherId);
+                $deferred->complete($stream);
             }
         );
 
-        return Internal\PromiseWrapper::createUnhandled($deferred->promise(), $this->unhandledFailingPromises);
+        return Internal\PromiseWrapper::createUnhandled($deferred->getFuture(), $this->unhandledFailingPromises);
     }
 
     public function __construct()
@@ -256,6 +253,5 @@ class EventLoop implements \M6Web\Tornado\EventLoop
         $this->unhandledFailingPromises = new Common\Internal\FailingPromiseCollection();
     }
 
-    /** @var Common\Internal\FailingPromiseCollection */
-    private $unhandledFailingPromises;
+    private Common\Internal\FailingPromiseCollection $unhandledFailingPromises;
 }

--- a/src/Adapter/Amp/EventLoop.php
+++ b/src/Adapter/Amp/EventLoop.php
@@ -12,6 +12,13 @@ use M6Web\Tornado\Promise;
 
 class EventLoop implements \M6Web\Tornado\EventLoop
 {
+    private Common\Internal\FailingPromiseCollection $unhandledFailingPromises;
+
+    public function __construct()
+    {
+        $this->unhandledFailingPromises = new Common\Internal\FailingPromiseCollection();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -158,7 +165,7 @@ class EventLoop implements \M6Web\Tornado\EventLoop
             $promises
         );
 
-        foreach ($futures as $index => $future) {
+        foreach ($futures as $future) {
             \Amp\async(fn () => $wrapPromise($future));
         }
 
@@ -255,11 +262,4 @@ class EventLoop implements \M6Web\Tornado\EventLoop
 
         return Internal\PromiseWrapper::createUnhandled($deferred->getFuture(), $this->unhandledFailingPromises);
     }
-
-    public function __construct()
-    {
-        $this->unhandledFailingPromises = new Common\Internal\FailingPromiseCollection();
-    }
-
-    private Common\Internal\FailingPromiseCollection $unhandledFailingPromises;
 }

--- a/src/Adapter/Amp/Internal/Deferred.php
+++ b/src/Adapter/Amp/Internal/Deferred.php
@@ -15,13 +15,13 @@ use M6Web\Tornado\Promise;
  */
 class Deferred implements \M6Web\Tornado\Deferred
 {
-  /**
-   * @param DeferredFuture<TValue> $ampDeferred
-   * @param PromiseWrapper<TValue> $promise
-   */
+    /**
+     * @param DeferredFuture<TValue> $ampDeferred
+     * @param PromiseWrapper<TValue> $promise
+     */
     public function __construct(
-      private readonly DeferredFuture $ampDeferred,
-      private readonly PromiseWrapper $promise,
+        private readonly DeferredFuture $ampDeferred,
+        private readonly PromiseWrapper $promise,
     ) {
     }
 

--- a/src/Adapter/Amp/Internal/Deferred.php
+++ b/src/Adapter/Amp/Internal/Deferred.php
@@ -34,14 +34,6 @@ class Deferred implements \M6Web\Tornado\Deferred
     }
 
     /**
-     * @return PromiseWrapper<TValue>
-     */
-    public function getPromiseWrapper(): PromiseWrapper
-    {
-        return $this->promise;
-    }
-
-    /**
      * @param TValue $value
      */
     public function resolve($value): void

--- a/src/Adapter/Amp/Internal/Deferred.php
+++ b/src/Adapter/Amp/Internal/Deferred.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace M6Web\Tornado\Adapter\Amp\Internal;
 
+use Amp\DeferredFuture;
 use M6Web\Tornado\Promise;
 
 /**
@@ -14,17 +15,14 @@ use M6Web\Tornado\Promise;
  */
 class Deferred implements \M6Web\Tornado\Deferred
 {
-    private \Amp\DeferredFuture $ampDeferred;
-    private PromiseWrapper $promise;
-
-
   /**
+   * @param DeferredFuture<TValue> $ampDeferred
    * @param PromiseWrapper<TValue> $promise
    */
-    public function __construct(\Amp\DeferredFuture $ampDeferred, PromiseWrapper $promise)
-    {
-        $this->ampDeferred = $ampDeferred;
-        $this->promise = $promise;
+    public function __construct(
+      private readonly DeferredFuture $ampDeferred,
+      private readonly PromiseWrapper $promise,
+    ) {
     }
 
     /**

--- a/src/Adapter/Amp/Internal/Deferred.php
+++ b/src/Adapter/Amp/Internal/Deferred.php
@@ -14,12 +14,17 @@ use M6Web\Tornado\Promise;
  */
 class Deferred implements \M6Web\Tornado\Deferred
 {
-    /**
-     * @param \Amp\Deferred<TValue>  $ampDeferred
-     * @param PromiseWrapper<TValue> $promise
-     */
-    public function __construct(private readonly \Amp\Deferred $ampDeferred, private readonly PromiseWrapper $promise)
+    private \Amp\DeferredFuture $ampDeferred;
+    private PromiseWrapper $promise;
+
+
+  /**
+   * @param PromiseWrapper<TValue> $promise
+   */
+    public function __construct(\Amp\DeferredFuture $ampDeferred, PromiseWrapper $promise)
     {
+        $this->ampDeferred = $ampDeferred;
+        $this->promise = $promise;
     }
 
     /**
@@ -43,7 +48,7 @@ class Deferred implements \M6Web\Tornado\Deferred
      */
     public function resolve($value): void
     {
-        $this->ampDeferred->resolve($value);
+        $this->ampDeferred->complete($value);
     }
 
     /**
@@ -51,6 +56,6 @@ class Deferred implements \M6Web\Tornado\Deferred
      */
     public function reject(\Throwable $throwable): void
     {
-        $this->ampDeferred->fail($throwable);
+        $this->ampDeferred->error($throwable);
     }
 }

--- a/src/Adapter/Amp/Internal/PromiseWrapper.php
+++ b/src/Adapter/Amp/Internal/PromiseWrapper.php
@@ -19,25 +19,21 @@ class PromiseWrapper implements Promise
 {
     /**
      * Use named (static) constructor instead
-     *
-     * @param \Amp\Promise<TValue> $ampPromise
      */
     private function __construct(
-        private readonly \Amp\Promise $ampPromise,
+        private readonly \Amp\Future $ampPromise,
         private bool $isHandled,
     ) {
     }
 
     /**
-     * @param \Amp\Promise<TValue> $ampPromise
-     *
      * @return self<TValue>
      */
-    public static function createUnhandled(\Amp\Promise $ampPromise, FailingPromiseCollection $failingPromiseCollection): self
+    public static function createUnhandled(\Amp\Future $ampPromise, FailingPromiseCollection $failingPromiseCollection): self
     {
         $promiseWrapper = new self($ampPromise, false);
-        $promiseWrapper->ampPromise->onResolve(
-            function (?\Throwable $reason, $value) use ($promiseWrapper, $failingPromiseCollection): void {
+        $promiseWrapper->ampPromise->catch(
+            function (?\Throwable $reason) use ($promiseWrapper, $failingPromiseCollection): void {
                 if ($reason !== null && !$promiseWrapper->isHandled) {
                     $failingPromiseCollection->watchFailingPromise($promiseWrapper, $reason);
                 }
@@ -48,19 +44,16 @@ class PromiseWrapper implements Promise
     }
 
     /**
-     * @param \Amp\Promise<TValue> $ampPromise
-     *
      * @return self<TValue>
      */
-    public static function createHandled(\Amp\Promise $ampPromise): self
+    public static function createHandled(\Amp\Future $ampPromise): self
     {
+      $ampPromise->ignore();
+
         return new self($ampPromise, true);
     }
 
-    /**
-     * @return \Amp\Promise<TValue>
-     */
-    public function getAmpPromise(): \Amp\Promise
+    public function getAmpFuture(): \Amp\Future
     {
         return $this->ampPromise;
     }
@@ -75,6 +68,7 @@ class PromiseWrapper implements Promise
         assert($promise instanceof self, new \Error('Input promise was not created by this adapter.'));
 
         $promise->isHandled = true;
+        $promise->getAmpFuture()->ignore();
         $failingPromiseCollection->unwatchPromise($promise);
 
         return $promise;

--- a/src/Adapter/Amp/Internal/PromiseWrapper.php
+++ b/src/Adapter/Amp/Internal/PromiseWrapper.php
@@ -21,10 +21,10 @@ class PromiseWrapper implements Promise
     /**
      * Use named (static) constructor instead
      *
-     * @param Future<TValue> $ampPromise
+     * @param Future<TValue> $ampFuture
      */
     private function __construct(
-        private readonly Future $ampPromise,
+        public readonly Future $ampFuture,
         private bool $isHandled,
     ) {
     }
@@ -35,7 +35,7 @@ class PromiseWrapper implements Promise
     public static function createUnhandled(Future $ampPromise, FailingPromiseCollection $failingPromiseCollection): self
     {
         $promiseWrapper = new self($ampPromise, false);
-        $promiseWrapper->ampPromise->catch(
+        $promiseWrapper->ampFuture->catch(
             function (?\Throwable $reason) use ($promiseWrapper, $failingPromiseCollection): void {
                 if ($reason !== null && !$promiseWrapper->isHandled) {
                     $failingPromiseCollection->watchFailingPromise($promiseWrapper, $reason);
@@ -57,14 +57,6 @@ class PromiseWrapper implements Promise
     }
 
     /**
-     * @return Future<TValue>
-     */
-    public function getAmpFuture(): Future
-    {
-        return $this->ampPromise;
-    }
-
-    /**
      * @param Promise<TValue> $promise
      *
      * @return self<TValue>
@@ -74,7 +66,7 @@ class PromiseWrapper implements Promise
         assert($promise instanceof self, new \Error('Input promise was not created by this adapter.'));
 
         $promise->isHandled = true;
-        $promise->getAmpFuture()->ignore();
+        $promise->ampFuture->ignore();
         $failingPromiseCollection->unwatchPromise($promise);
 
         return $promise;

--- a/src/Adapter/Amp/Internal/PromiseWrapper.php
+++ b/src/Adapter/Amp/Internal/PromiseWrapper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace M6Web\Tornado\Adapter\Amp\Internal;
 
+use Amp\Future;
 use M6Web\Tornado\Adapter\Common\Internal\FailingPromiseCollection;
 use M6Web\Tornado\Promise;
 
@@ -19,9 +20,11 @@ class PromiseWrapper implements Promise
 {
     /**
      * Use named (static) constructor instead
+     *
+     * @param Future<TValue> $ampPromise
      */
     private function __construct(
-        private readonly \Amp\Future $ampPromise,
+        private readonly Future $ampPromise,
         private bool $isHandled,
     ) {
     }
@@ -29,7 +32,7 @@ class PromiseWrapper implements Promise
     /**
      * @return self<TValue>
      */
-    public static function createUnhandled(\Amp\Future $ampPromise, FailingPromiseCollection $failingPromiseCollection): self
+    public static function createUnhandled(Future $ampPromise, FailingPromiseCollection $failingPromiseCollection): self
     {
         $promiseWrapper = new self($ampPromise, false);
         $promiseWrapper->ampPromise->catch(
@@ -46,14 +49,17 @@ class PromiseWrapper implements Promise
     /**
      * @return self<TValue>
      */
-    public static function createHandled(\Amp\Future $ampPromise): self
+    public static function createHandled(Future $ampPromise): self
     {
       $ampPromise->ignore();
 
         return new self($ampPromise, true);
     }
 
-    public function getAmpFuture(): \Amp\Future
+  /**
+   * @return Future<TValue>
+   */
+    public function getAmpFuture(): Future
     {
         return $this->ampPromise;
     }

--- a/src/Adapter/Amp/Internal/PromiseWrapper.php
+++ b/src/Adapter/Amp/Internal/PromiseWrapper.php
@@ -51,14 +51,14 @@ class PromiseWrapper implements Promise
      */
     public static function createHandled(Future $ampPromise): self
     {
-      $ampPromise->ignore();
+        $ampPromise->ignore();
 
         return new self($ampPromise, true);
     }
 
-  /**
-   * @return Future<TValue>
-   */
+    /**
+     * @return Future<TValue>
+     */
     public function getAmpFuture(): Future
     {
         return $this->ampPromise;

--- a/src/Adapter/Tornado/SynchronousEventLoop.php
+++ b/src/Adapter/Tornado/SynchronousEventLoop.php
@@ -155,11 +155,9 @@ class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
      */
     public function deferred(): Deferred
     {
-        $deferred = new class implements Deferred {
-            /** @var SynchronousEventLoop */
-            public $eventLoop;
-            /** @var ?Promise<mixed> */
-            private $promise;
+        $deferred = new class() implements Deferred {
+            public SynchronousEventLoop $eventLoop;
+            private ?Promise $promise = null;
 
             public function getPromise(): Promise
             {

--- a/src/Adapter/Tornado/SynchronousEventLoop.php
+++ b/src/Adapter/Tornado/SynchronousEventLoop.php
@@ -155,7 +155,7 @@ class SynchronousEventLoop implements \M6Web\Tornado\EventLoop
      */
     public function deferred(): Deferred
     {
-        $deferred = new class() implements Deferred {
+        $deferred = new class implements Deferred {
             public SynchronousEventLoop $eventLoop;
             private ?Promise $promise = null;
 

--- a/tests/Adapter/Amp/EventLoopTest.php
+++ b/tests/Adapter/Amp/EventLoopTest.php
@@ -6,8 +6,9 @@ namespace M6WebTest\Tornado\Adapter\Amp;
 
 use M6Web\Tornado\Adapter\Amp;
 use M6Web\Tornado\EventLoop;
+use M6WebTest\Tornado\EventLoopTestCase;
 
-class EventLoopTest extends \M6WebTest\Tornado\EventLoopTestCase
+class EventLoopTest extends EventLoopTestCase
 {
     protected function createEventLoop(): EventLoop
     {
@@ -22,7 +23,6 @@ class EventLoopTest extends \M6WebTest\Tornado\EventLoopTestCase
 
     protected function tearDown(): void
     {
-        \Amp\Loop::set((new \Amp\Loop\DriverFactory())->create());
         gc_collect_cycles(); // extensions using an event loop may otherwise leak the file descriptors to the loop
     }
 }

--- a/tests/EventLoopTest/PromiseAllTestTrait.php
+++ b/tests/EventLoopTest/PromiseAllTestTrait.php
@@ -101,4 +101,18 @@ trait PromiseAllTestTrait
             $eventLoop->wait($eventLoop->async($createGenerator()))
         );
     }
+
+    public function testPromiseAllShouldPreserveTheOrderOfArrayWithStringKeys(): void
+    {
+        $eventLoop = $this->createEventLoop();
+        $expectedValues = [
+            'c' => 1,
+            'a' => 2,
+            'b' => 3,
+        ];
+        $promises = \array_map([$eventLoop, 'promiseFulfilled'], $expectedValues);
+        $promise = $eventLoop->promiseAll(...$promises);
+
+        $this->assertSame($expectedValues, $eventLoop->wait($promise));
+    }
 }

--- a/tests/EventLoopTest/PromiseForeachTestTrait.php
+++ b/tests/EventLoopTest/PromiseForeachTestTrait.php
@@ -43,7 +43,6 @@ trait PromiseForeachTestTrait
     {
         $eventLoop = $this->createEventLoop();
         $callback = function (): void {
-            return;
         };
 
         $this->expectException(\TypeError::class);

--- a/tests/EventLoopTest/StreamsTestTrait.php
+++ b/tests/EventLoopTest/StreamsTestTrait.php
@@ -48,7 +48,6 @@ trait StreamsTestTrait
                 $sequence .= "W$token";
                 // Write twice slower
                 yield $eventLoop->idle();
-                // yield $eventLoop->idle();
             }
             fclose($stream);
         };


### PR DESCRIPTION
AMPHP use now Fiber via Revolt eventloop. 
I made this PR to update the current AMPHP implementation of Tornado to this new version. 
I don't think it's a good idea to keep both implementation of AMP (2.6 and 3.0)

- Drop of the PHP 7.4 version was needed.   
- I also update PHPStan version 

## Documentaion
https://amphp.org/upgrade
https://revolt.run/fundamentals